### PR TITLE
Context manager dunder methods, create_dataset from data, infer filetype from extension, file permissions

### DIFF
--- a/src/python/module/z5py/base.py
+++ b/src/python/module/z5py/base.py
@@ -1,5 +1,6 @@
 import os
 import json
+import numpy as np
 from .dataset import Dataset
 from .attribute_manager import AttributeManager
 
@@ -28,15 +29,45 @@ class Base(object):
     # TODO open_dataset, open_group and close_group should also be implemented here
 
     # TODO allow creating with data ?!
-    def create_dataset(self, key, dtype, shape, chunks,
-                       fill_value=0, compression='raw',
+    def create_dataset(self, key, dtype=None, shape=None, chunks=None,
+                       fill_value=0, compression='raw', data=None,
                        **compression_options):
         assert key not in self.keys(), "Dataset is already existing"
+
+        if data is None:
+            assert shape is not None, "Datasets must be given a shape"
+            assert chunks is not None, "Datasets must be given a chunk size"
+            dtype = dtype or np.dtype('float64')
+        else:
+            data = np.asarray(data)
+            if dtype is None:
+                dtype = data.dtype
+            else:
+                assert dtype == data.dtype, "Given dtype ({}) conflicts with type of given data ({})".format(
+                    dtype, data.dtype
+                )  # could coerce instead
+
+            if shape is None:
+                shape = dtype.shape
+            else:
+                assert shape == data.shape, "Given shape ({}) conflicts with shape of given data ({})".format(
+                    shape, data.shape
+                )
+
+            if chunks is None:
+                chunks = shape  # contiguous
+
         path = os.path.join(self.path, key)
-        return Dataset.create_dataset(path, dtype, shape,
+        ds = Dataset.create_dataset(path, dtype, shape,
                                       chunks, self.is_zarr,
                                       compression, compression_options,
                                       fill_value)
+
+        if data is None:
+            return ds
+
+        ds[:, :, :] = data
+        return ds
 
     def is_group(self, key):
         path = os.path.join(self.path, key)

--- a/src/python/module/z5py/file.py
+++ b/src/python/module/z5py/file.py
@@ -85,3 +85,9 @@ class File(Base):
             return Dataset.open_dataset(path)
 
     # TODO setitem, delete datasets ?
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass

--- a/src/python/module/z5py/file.py
+++ b/src/python/module/z5py/file.py
@@ -11,6 +11,10 @@ except ImportError:
     JSONDecodeError = ValueError
 
 
+ZARR_EXTS = {'.zarr'}
+N5_EXTS = {'.n5'}
+
+
 class File(Base):
 
     def __init__(self, path, use_zarr_format=None):
@@ -35,6 +39,13 @@ class File(Base):
 
         # otherwise create a new file
         else:
+            if use_zarr_format is None:
+                _, ext = os.path.splitext(path)
+                if ext.lower() in ZARR_EXTS:
+                    use_zarr_format = True
+                elif ext.lower() in N5_EXTS:
+                    use_zarr_format = False
+
             assert use_zarr_format is not None, \
                 "z5py.File: Cannot infer the file format for non existing file"
             os.mkdir(path)

--- a/src/python/module/z5py/group.py
+++ b/src/python/module/z5py/group.py
@@ -1,4 +1,5 @@
 import os
+from .modes import FileMode
 from .base import Base
 from ._z5py import create_group
 from .dataset import Dataset
@@ -6,27 +7,30 @@ from .dataset import Dataset
 
 class Group(Base):
 
-    def __init__(self, path, is_zarr=True):
-        super(Group, self).__init__(path, is_zarr)
+    def __init__(self, path, is_zarr=True, mode='a'):
+        super(Group, self).__init__(path, is_zarr, mode)
 
     @classmethod
-    def make_group(cls, path, is_zarr):
+    def make_group(cls, path, is_zarr, mode='a'):
+        mode = FileMode(mode)
+        mode.check_write(path)
         create_group(path, is_zarr)
-        return cls(path, is_zarr)
+        return cls(path, is_zarr, mode)
 
     @classmethod
-    def open_group(cls, path, is_zarr):
-        return cls(path, is_zarr)
+    def open_group(cls, path, is_zarr, mode='a'):
+        return cls(path, is_zarr, mode)
 
     def create_group(self, key):
         assert key not in self.keys(), "Group is already existing"
         path = os.path.join(self.path, key)
-        return Group.make_group(path, self.is_zarr)
+        self.mode.can_write(path)
+        return Group.make_group(path, self.is_zarr, self.mode)
 
     def __getitem__(self, key):
         assert key in self, "z5py.File.__getitem__: key does not exxist"
         path = os.path.join(self.path, key)
         if self.is_group(key):
-            return Group.open_group(path, self.is_zarr)
+            return Group.open_group(path, self.is_zarr, self.mode)
         else:
-            return Dataset.open_dataset(path)
+            return Dataset.open_dataset(path, self.mode)

--- a/src/python/module/z5py/modes.py
+++ b/src/python/module/z5py/modes.py
@@ -1,0 +1,55 @@
+import os
+import errno
+import shutil
+
+DEFAULT = 'a'
+
+MODES = {'r', 'r+', 'w', 'w-', 'x', 'a'}
+
+MUST_EXIST = {'r', 'r+'}
+MUST_NOT_EXIST = {'w-', 'x'}
+CAN_WRITE = {'w', 'w-', 'x', 'a', 'r+'}
+SHOULD_TRUNCATE = {'w'}
+
+
+class FileMode(object):
+    def __init__(self, mode='a'):
+        mode_as_str = str(mode)
+        if mode_as_str not in MODES:
+            raise ValueError('Mode {} does not exist: must be one of ({})'.format(mode, ', '.join(sorted(MODES))))
+        self.value = mode_as_str
+
+        self.file_must_exist = mode_as_str in MUST_EXIST
+        self.file_must_not_exist = mode_as_str in MUST_NOT_EXIST
+        self.can_write = mode_as_str in CAN_WRITE
+        self.should_truncate_file = mode_as_str in SHOULD_TRUNCATE
+
+    def check_file(self, path):
+        """Raise errors as appropriate given file permissions, truncate if necessary, then return whether path exists"""
+        if os.path.exists(path):
+            if self.file_must_not_exist:
+                raise OSError(errno.EEXIST, os.strerror(errno.EEXIST), path)
+            if self.should_truncate_file:
+                shutil.rmtree(path)
+            else:
+                return True
+
+        if not os.path.exists(path):
+            if self.file_must_exist:
+                raise OSError(errno.ENOENT, os.strerror(errno.ENOENT), path)
+            return False
+
+    def check_write(self, path):
+        """Raise error as appropriate given file permissions, then return whether path exists"""
+        if not self.can_write:
+            raise OSError(errno.EROFS, os.strerror(errno.EROFS), path)
+        return os.path.exists(path)
+
+    def __str__(self):
+        return self.value
+
+    def __hash__(self):
+        return hash(self.value)
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)


### PR DESCRIPTION
# WIP

PR for discussion purposes. I recommend going through one commit at a time.

I haven't tested anything yet. As someone who doesn't really deal with 'real' programming languages day-to-day, do I need to do anything build-related to run tests?

## Context manager dunder methods 

https://github.com/constantinpape/z5/commit/7a20d5f5927059060773ae2d9a534059aa52999a

Even though `with` clauses aren't necessary, it's nice for them to not throw errors, in case anyone wants to drop in z5py as a replacement for h5py. This commit adds trivial implementations.

## create_dataset from data

https://github.com/constantinpape/z5/pull/29/commits/14dd9a30edf7668b4b32b8e969c8b67ffe5acd44

It's convenient to do this. Only implemented in `Base.create_dataset`, as datasets shouldn't be created standalone anyway. Required giving defaults to some positional arguments. Added a h5py-like default dtype of 'float64'. If `chunks` is not given, the chunk size is the size of the passed-in array (so that it's contiguous like h5py).

## Infer filetype from extension

https://github.com/constantinpape/z5/pull/29/commits/07fff82ed7ebabf8644bc507ac2060c0e6c4708b

`path/to/data.n5` implies n5, `path/to/data.zarr` implies zarr. Top-level `File` only.

##  File permissions

https://github.com/constantinpape/z5/pull/29/commits/0d15ea52aeae6595346e3f5d6c5c1acd376f7cf8

As noted in #28. This needs lots of testing: it's not "safe" by any means, and assumes people will only be creating and opening groups and datasets via opening a File. Uses h5py convention whereby only the top-level object is a File: objects without permission to create a z5py.File may have permission to create an OS file.