### PR TITLE
File: Add trivial context manager dunder

### DIFF
--- a/src/python/module/z5py/file.py
+++ b/src/python/module/z5py/file.py
@@ -85,3 +85,9 @@ class File(Base):
             return Dataset.open_dataset(path)
 
     # TODO setitem, delete datasets ?
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass


### PR DESCRIPTION
Previously, __enter__ and __exit__ were not defined, meaning that z5py
could not be used as a drop-in replacement for h5py. Now they have
trivial definitions which currently have no value besides having a more
h5pythonic interface.