### PR TITLE
Handle nonexistent attribute files

### DIFF
--- a/src/python/module/z5py/attribute_manager.py
+++ b/src/python/module/z5py/attribute_manager.py
@@ -1,5 +1,6 @@
 import json
 import os
+import errno
 
 
 class AttributeManager(object):
@@ -49,6 +50,11 @@ class AttributeManager(object):
                 attrs = json.load(f)
         except ValueError:
             attrs = {}
+        except IOError as e:
+            if e.errno == errno.ENOENT:
+                attrs = {}
+            else:
+                raise
         return attrs
 
     def _get_n5_attributes(self):

--- a/src/python/test/test_attributes.py
+++ b/src/python/test/test_attributes.py
@@ -15,6 +15,8 @@ except ImportError:
 class TestAttributes(unittest.TestCase):
 
     def attrs_test(self, attrs):
+        self.assertFalse('not_an_attr' in attrs)
+
         attrs["a"] = 1
         attrs["b"] = [1, 2, 3]
         attrs["c"] = "whooosa"


### PR DESCRIPTION
Under zarr v2, .zattrs file is optional. However, in z5py an error
would be thrown if iterating through or doing membership checks of
attributes when that file did not exist.

Now the error is caught and an empty dict returned.