### PR TITLE
File: Add direct constructors for Zarr, N5 files

### DIFF
--- a/src/python/module/z5py/__init__.py
+++ b/src/python/module/z5py/__init__.py
@@ -1,1 +1,1 @@
-from .file import File
+from .file import File, N5File, ZarrFile

--- a/src/python/module/z5py/file.py
+++ b/src/python/module/z5py/file.py
@@ -18,8 +18,8 @@ class File(Base):
     zarr_exts = {'.zarr', '.zr'}
     n5_exts = {'.n5'}
 
-    @staticmethod
-    def infer_format(path):
+    @classmethod
+    def infer_format(cls, path):
         """
         Infer the file format from the path.
         Return `True` for zarr, `False` for n5 and `None` if the format could not be infered.
@@ -33,9 +33,9 @@ class File(Base):
         else:
             is_zarr = None
             _, ext = os.path.splitext(path)
-            if ext.lower() in File.zarr_exts:
+            if ext.lower() in cls.zarr_exts:
                 is_zarr = True
-            elif ext.lower() in File.n5_exts:
+            elif ext.lower() in cls.n5_exts:
                 is_zarr = False
             return is_zarr
 
@@ -50,7 +50,7 @@ class File(Base):
             use_zarr_format = is_zarr
 
         elif use_zarr_format:
-            if not is_zarr:
+            if is_zarr == False:
                 raise RuntimeError("N5 file cannot be opened in zarr format")
 
         else:
@@ -132,3 +132,13 @@ class File(Base):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
+
+
+class N5File(File):
+    def __init__(self, path, mode='a'):
+        super(N5File, self).__init__(path=path, use_zarr_format=False, mode=mode)
+
+
+class ZarrFile(File):
+    def __init__(self, path, mode='a'):
+        super(ZarrFile, self).__init__(path=path, use_zarr_format=True, mode=mode)

--- a/src/python/test/test_file.py
+++ b/src/python/test/test_file.py
@@ -57,3 +57,22 @@ class TestFile(unittest.TestCase):
 
         f = z5py.File(self.zarr_path, None)
         self.assertTrue(f.is_zarr)
+
+    def test_direct_constructor_n5(self):
+        self.assertFalse(os.path.exists(self.n5_path))
+
+        f = z5py.N5File(self.n5_path)
+        self.assertFalse(f.is_zarr)
+
+    def test_direct_constructor_zarr(self):
+        self.assertFalse(os.path.exists(self.zarr_path))
+
+        f = z5py.ZarrFile(self.zarr_path)
+        self.assertTrue(f.is_zarr)
+
+    def test_wrong_ext_fails(self):
+        with self.assertRaises(RuntimeError):
+            f = z5py.File(self.zarr_path, use_zarr_format=False)
+
+        with self.assertRaises(RuntimeError):
+            f = z5py.File(self.n5_path, use_zarr_format=True)

--- a/src/python/test/test_file.py
+++ b/src/python/test/test_file.py
@@ -21,6 +21,8 @@ class TestFile(unittest.TestCase):
             rmtree(self.n5_path)
         if(os.path.exists(self.zr_path)):
             rmtree(self.zr_path)
+        if(os.path.exists(self.zarr_path)):
+            rmtree(self.zarr_path)
 
     def test_context_manager_n5(self):
         self.assertFalse(os.path.exists(self.n5_path))


### PR DESCRIPTION
These just inherit from and call the constructor of File.

Minor changes:

- fixed bug where zarr files could not be created unless they had the
correct extension, even if `use_zarr_format` was given explicitly

This is a minor convenience, no need to rush a release out once it's merged.