### PR TITLE
AttributeManager refactor and Dataset dtype specs

### DIFF
--- a/src/python/module/z5py/attribute_manager.py
+++ b/src/python/module/z5py/attribute_manager.py
@@ -7,21 +7,21 @@ from contextlib import contextmanager
 try:
     from collections.abc import MutableMapping
 except ImportError:
-    from collections import MutableMapping       
+    from collections import MutableMapping
 
 
 __all__ = ['AttributeManager']
 
 
-def restrict_n5_keys(fn):
+def restrict_metadata_keys(fn):
     """
     Decorator for AttributeManager methods which checks that, if the manager is for N5, the key argument is not a
     reserved metadata name.
     """
     @wraps(fn)
     def wrapped(obj, key, *args, **kwargs):
-        if not obj.is_zarr and key in obj.n5_keys:
-            raise RuntimeError("N5 metadata (key {}) cannot be mutated".format(repr(key)))
+        if key in obj.reserved_keys:
+            raise RuntimeError("Reserved metadata (key {}) cannot be mutated".format(repr(key)))
         return fn(obj, key, *args, **kwargs)
     return wrapped
 
@@ -33,31 +33,33 @@ class AttributeManager(MutableMapping):
 
     def __init__(self, path, is_zarr):
         self.path = os.path.join(path, self.zarr_fname if is_zarr else self.n5_fname)
-        self.is_zarr = is_zarr
+        self.reserved_keys = frozenset() if is_zarr else self.n5_keys
 
     def __getitem__(self, key):
         with self._open_attributes() as attributes:
             return attributes[key]
 
-    @restrict_n5_keys
+    @restrict_metadata_keys
     def __setitem__(self, key, item):
         with self._open_attributes(True) as attributes:
             attributes[key] = item
 
-    @restrict_n5_keys
+    @restrict_metadata_keys
     def __delitem__(self, key):
         with self._open_attributes(True) as attributes:
             del attributes[key]
 
     @contextmanager
     def _open_attributes(self, write=False):
-        """Context manager for JSON attribute store. Caller needs to distinguish between valid and N5 metadata keys.
+        """Context manager for JSON attribute store.
 
         Set ``write`` to True to dump out changes."""
         attributes = self._read_attributes()
+        hidden_attrs = {key: attributes.pop(key) for key in self.reserved_keys.intersection(attributes)}
         yield attributes
         if write:
-            self._write_attributes(attributes)
+            hidden_attrs.update(attributes)
+            self._write_attributes(hidden_attrs)
 
     def _read_attributes(self):
         """Return dict from JSON attribute store. Caller needs to distinguish between valid and N5 metadata keys."""
@@ -75,20 +77,14 @@ class AttributeManager(MutableMapping):
         return attributes
 
     def _write_attributes(self, attributes):
-        """Dump ``attributes`` to JSON"""
+        """Dump ``attributes`` to JSON. Potentially dangerous for N5 metadata."""
         with open(self.path, 'w') as f:
             json.dump(attributes, f)
 
     def __iter__(self):
         with self._open_attributes() as attributes:
-            if not self.is_zarr:
-                for key in self.n5_keys:
-                    attributes.pop(key, None)
             return iter(attributes)
 
     def __len__(self):
-        return len(list(self))
-
-    def __contains__(self, item):
         with self._open_attributes() as attributes:
-            return item in attributes and (self.is_zarr or item not in self.n5_keys)
+            return len(attributes)

--- a/src/python/module/z5py/attribute_manager.py
+++ b/src/python/module/z5py/attribute_manager.py
@@ -1,81 +1,94 @@
 import json
 import os
 import errno
+from functools import wraps
+from contextlib import contextmanager
+
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping       
 
 
-class AttributeManager(object):
+__all__ = ['AttributeManager']
 
-    n5_keys = ('dimensions', 'blockSize', 'dataType', 'compressionType', 'compression')
+
+def restrict_n5_keys(fn):
+    """
+    Decorator for AttributeManager methods which checks that, if the manager is for N5, the key argument is not a
+    reserved metadata name.
+    """
+    @wraps(fn)
+    def wrapped(obj, key, *args, **kwargs):
+        if not obj.is_zarr and key in obj.n5_keys:
+            raise RuntimeError("N5 metadata (key {}) cannot be mutated".format(repr(key)))
+        return fn(obj, key, *args, **kwargs)
+    return wrapped
+
+
+class AttributeManager(MutableMapping):
+    zarr_fname = '.zattributes'
+    n5_fname = 'attributes.json'
+    n5_keys = frozenset(('dimensions', 'blockSize', 'dataType', 'compressionType', 'compression'))
 
     def __init__(self, path, is_zarr):
-        self.path = os.path.join(path, '.zattrs' if is_zarr else 'attributes.json')
+        self.path = os.path.join(path, self.zarr_fname if is_zarr else self.n5_fname)
         self.is_zarr = is_zarr
 
     def __getitem__(self, key):
+        with self._open_attributes() as attributes:
+            return attributes[key]
 
-        if not os.path.exists(self.path):
-            raise KeyError("No attributes present!")
-
-        with open(self.path, 'r') as f:
-            attributes = json.load(f)
-
-        if key not in attributes:
-            raise KeyError("Key %s is not existing" % key)
-        return attributes[key]
-
+    @restrict_n5_keys
     def __setitem__(self, key, item):
+        with self._open_attributes(True) as attributes:
+            attributes[key] = item
 
-        if not self.is_zarr:
-            if key in self.n5_keys:
-                raise RuntimeError("It is not allowed to write N5 metadata keys")
+    @restrict_n5_keys
+    def __delitem__(self, key):
+        with self._open_attributes(True) as attributes:
+            del attributes[key]
 
-        if os.path.exists(self.path):
+    @contextmanager
+    def _open_attributes(self, write=False):
+        """Context manager for JSON attribute store. Caller needs to distinguish between valid and N5 metadata keys.
+
+        Set ``write`` to True to dump out changes."""
+        attributes = self._read_attributes()
+        yield attributes
+        if write:
+            self._write_attributes(attributes)
+
+    def _read_attributes(self):
+        """Return dict from JSON attribute store. Caller needs to distinguish between valid and N5 metadata keys."""
+        try:
             with open(self.path, 'r') as f:
-                # json cannot decode empty files,
-                # which may appear for N5 files
-                try:
-                    attributes = json.load(f)
-                except ValueError:
-                    attributes = {}
-        else:
+                attributes = json.load(f)
+        except ValueError:
             attributes = {}
+        except IOError as e:
+            if e.errno == errno.ENOENT:
+                attributes = {}
+            else:
+                raise
 
-        attributes[key] = item
+        return attributes
+
+    def _write_attributes(self, attributes):
+        """Dump ``attributes`` to JSON"""
         with open(self.path, 'w') as f:
             json.dump(attributes, f)
 
-    def _get_attributes(self):
-        try:
-            with open(self.path, 'r') as f:
-                attrs = json.load(f)
-        except ValueError:
-            attrs = {}
-        except IOError as e:
-            if e.errno == errno.ENOENT:
-                attrs = {}
-            else:
-                raise
-        return attrs
+    def __iter__(self):
+        with self._open_attributes() as attributes:
+            if not self.is_zarr:
+                for key in self.n5_keys:
+                    attributes.pop(key, None)
+            return iter(attributes)
 
-    def _get_n5_attributes(self):
-        attrs = self._get_attributes()
-        for key in self.n5_keys:
-            if key in attrs:
-                del attrs[key]
-        return attrs
+    def __len__(self):
+        return len(list(self))
 
     def __contains__(self, item):
-        attrs = self._get_attributes() if self.is_zarr else self._get_n5_attributes()
-        return item in attrs
-
-    def items(self):
-        attrs = self._get_attributes() if self.is_zarr else self._get_n5_attributes()
-        return attrs.items()
-
-    def keys(self):
-        attrs = self._get_attributes() if self.is_zarr else self._get_n5_attributes()
-        return attrs.keys()
-
-    def values(self):
-        attrs = self._get_attributes() if self.is_zarr else self._get_n5_attributes()
-        return attrs.values()
+        with self._open_attributes() as attributes:
+            return item in attributes and (self.is_zarr or item not in self.n5_keys)

--- a/src/python/module/z5py/dataset.py
+++ b/src/python/module/z5py/dataset.py
@@ -163,19 +163,17 @@ class Dataset(object):
         elif not is_zarr and compression not in cls.compressors_n5:
             compression = cls.n5_default_compressor
 
-        # support for numpy datatypes
-        if not isinstance(dtype, str):
-            if dtype not in cls.dtype_dict:
-                raise ValueError("Invalid data type")
-            dtype_ = cls.dtype_dict[dtype]
-        else:
-            dtype_ = dtype
+        parsed_dtype = np.dtype(dtype)
 
         if is_zarr:
-            cls._create_dataset_zarr(path, dtype_, shape, chunks,
+            if parsed_dtype not in cls.zarr_dtype_dict:
+                raise ValueError("Invalid data type {} for zarr dataset".format(dtype))
+            cls._create_dataset_zarr(path, parsed_dtype, shape, chunks,
                                      compression, compression_options, fill_value)
         else:
-            cls._create_dataset_n5(path, dtype_, shape, chunks,
+            if parsed_dtype not in cls.dtype_dict:
+                raise ValueError("Invalid data type {} for N5 dataset".format(repr(dtype)))
+            cls._create_dataset_n5(path, parsed_dtype, shape, chunks,
                                    compression, compression_options)
         return cls(path, open_dataset(path, mode))
 

--- a/src/python/test/test_attributes.py
+++ b/src/python/test/test_attributes.py
@@ -14,7 +14,7 @@ except ImportError:
 
 class TestAttributes(unittest.TestCase):
 
-    def attrs_test(self, attrs):
+    def check_attrs(self, attrs):
         self.assertFalse('not_an_attr' in attrs)
 
         attrs["a"] = 1
@@ -23,6 +23,16 @@ class TestAttributes(unittest.TestCase):
         self.assertEqual(attrs["a"], 1)
         self.assertEqual(attrs["b"], [1, 2, 3])
         self.assertEqual(attrs["c"], "whooosa")
+
+    def check_n5_ds_attrs(self, attrs):
+        for key in attrs.n5_keys:
+            with self.assertRaises(RuntimeError):
+                attrs[key] = 5
+
+            with self.assertRaises(RuntimeError):
+                del attrs[key]
+
+            self.assertFalse(key in attrs)
 
     def setUp(self):
         self.shape = (100, 100, 100)
@@ -50,34 +60,35 @@ class TestAttributes(unittest.TestCase):
         # test file attributes
         f_attrs = self.ff_zarr.attrs
         print("Zarr: File Attribute Test")
-        self.attrs_test(f_attrs)
+        self.check_attrs(f_attrs)
 
         # test group attributes
         f_group = self.ff_zarr["group"].attrs
         print("Zarr: Group Attribute Test")
-        self.attrs_test(f_group)
+        self.check_attrs(f_group)
 
         # test ds attributes
         f_ds = self.ff_zarr["ds"].attrs
         print("Zarr: Dataset Attribute Test")
-        self.attrs_test(f_ds)
+        self.check_attrs(f_ds)
 
     def test_attrs_n5(self):
 
         # test file attributes
         print("N5: File Attribute Test")
         f_attrs = self.ff_n5.attrs
-        self.attrs_test(f_attrs)
+        self.check_attrs(f_attrs)
 
         # test group attributes
         print("N5: Group Attribute Test")
         f_group = self.ff_n5["group"].attrs
-        self.attrs_test(f_group)
+        self.check_attrs(f_group)
 
         # test ds attributes
         print("N5: Dataset Attribute Test")
         f_ds = self.ff_n5["ds"].attrs
-        self.attrs_test(f_ds)
+        self.check_attrs(f_ds)
+        self.check_n5_ds_attrs(f_ds)
 
 
 if __name__ == '__main__':

--- a/src/python/test/test_attributes.py
+++ b/src/python/test/test_attributes.py
@@ -24,15 +24,17 @@ class TestAttributes(unittest.TestCase):
         self.assertEqual(attrs["b"], [1, 2, 3])
         self.assertEqual(attrs["c"], "whooosa")
 
-    def check_n5_ds_attrs(self, attrs):
-        for key in attrs.n5_keys:
+    def check_ds_attrs(self, attrs):
+        for key in attrs.reserved_keys:
             with self.assertRaises(RuntimeError):
                 attrs[key] = 5
 
             with self.assertRaises(RuntimeError):
                 del attrs[key]
 
+            self.assertIsNone(attrs.get(key))
             self.assertFalse(key in attrs)
+            self.assertFalse(key in set(attrs))
 
     def setUp(self):
         self.shape = (100, 100, 100)
@@ -71,6 +73,7 @@ class TestAttributes(unittest.TestCase):
         f_ds = self.ff_zarr["ds"].attrs
         print("Zarr: Dataset Attribute Test")
         self.check_attrs(f_ds)
+        self.check_ds_attrs(f_ds)
 
     def test_attrs_n5(self):
 
@@ -88,7 +91,7 @@ class TestAttributes(unittest.TestCase):
         print("N5: Dataset Attribute Test")
         f_ds = self.ff_n5["ds"].attrs
         self.check_attrs(f_ds)
-        self.check_n5_ds_attrs(f_ds)
+        self.check_ds_attrs(f_ds)
 
 
 if __name__ == '__main__':

--- a/src/python/test/test_dataset.py
+++ b/src/python/test/test_dataset.py
@@ -24,6 +24,28 @@ class TestDataset(unittest.TestCase):
             'test', dtype='float32', shape=self.shape, chunks=(10, 10, 10)
         )
 
+        base_dtypes = [
+            'int8', 'int16', 'int32', 'int64',
+            'uint8', 'uint16', 'uint32', 'uint64',
+            'float32', 'float64'
+        ]
+        self.dtypes = tuple(
+            base_dtypes +
+            [
+                np.dtype(s) for s in base_dtypes
+            ] +
+            [
+                '<i1', '<i2', '<i4', '<i8',
+                '<u1', '<u2', '<u4', '<u8',
+                '<f4', '<f8'
+            ] +
+            [
+                np.int8, np.int16, np.int32, np.int64,
+                np.uint8, np.uint16, np.uint32, np.uint64,
+                np.float32, np.float64
+            ]
+        )
+
     def tearDown(self):
         if(os.path.exists('array.zr')):
             rmtree('array.zr')
@@ -45,14 +67,10 @@ class TestDataset(unittest.TestCase):
         self.assertTrue((out == 0).all())
 
     def test_ds_zarr(self):
-        dtypes = ('int8', 'int16', 'int32', 'int64',
-                  'uint8', 'uint16', 'uint32', 'uint64',
-                  'float32', 'float64')
-
-        for dtype in dtypes:
+        for dtype in self.dtypes:
             print("Running Zarr-Test for %s" % dtype)
             ds = self.ff_zarr.create_dataset(
-                'data_%s' % dtype, dtype=dtype, shape=self.shape, chunks=(10, 10, 10)
+                'data_%s' % hash(dtype), dtype=dtype, shape=self.shape, chunks=(10, 10, 10)
             )
             in_array = 42 * np.ones(self.shape, dtype=dtype)
             ds[:] = in_array
@@ -61,14 +79,10 @@ class TestDataset(unittest.TestCase):
             self.assertTrue(np.allclose(out_array, in_array))
 
     def test_ds_n5(self):
-        dtypes = ('int8', 'int16', 'int32', 'int64',
-                  'uint8', 'uint16', 'uint32', 'uint64',
-                  'float32', 'float64')
-
-        for dtype in dtypes:
+        for dtype in self.dtypes:
             print("Running N5-Test for %s" % dtype)
             ds = self.ff_n5.create_dataset(
-                'data_%s' % dtype, dtype=dtype, shape=self.shape, chunks=(10, 10, 10)
+                'data_%s' % hash(dtype), dtype=dtype, shape=self.shape, chunks=(10, 10, 10)
             )
             in_array = 42 * np.ones(self.shape, dtype=dtype)
             ds[:] = in_array
@@ -78,12 +92,8 @@ class TestDataset(unittest.TestCase):
 
     @unittest.skipIf(sys.version_info.major < 3, "This fails in python 2")
     def test_ds_n5_array_to_format(self):
-        dtypes = ('int8', 'int16', 'int32', 'int64',
-                  'uint8', 'uint16', 'uint32', 'uint64',
-                  'float32', 'float64')
-
-        for dtype in dtypes:
-            ds = self.ff_n5.create_dataset('data_%s' % dtype,
+        for dtype in self.dtypes:
+            ds = self.ff_n5.create_dataset('data_%s' % hash(dtype),
                                            dtype=dtype,
                                            shape=self.shape,
                                            chunks=(10, 10, 10))


### PR DESCRIPTION
AttributeManager was missing some behaviour because h5py's inherits from MutableMapping, so I've refactored it to do the same, among some other minor changes.

Datasets could not be created with certain types of dtype spec (e.g. `np.uint8`), so I've made a small change to allow that too.

Query: in the existing implementation, N5 metadata can be addressed through the AttributeManager using `__getitem__`, but zarr metadata cannot. Neither can be written through the AttributeManager (which I agree with), and neither show up when iterating through or doing membership checks - the latter is inconsistent given the `__getitem__` behaviour. I think it makes more sense for N5 metadata to be invisible to the AttributeManager regardless of you how access it, just like it is for zarr. The new implementation keeps the current behaviour, but would be simpler if we ironed out the inconsistency.