### PR TITLE
Mthread cpp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+addons:
+  apt:
+    update: true
 
 before_script:
   # TODO conda 2 for python 2.7
@@ -20,7 +23,7 @@ before_script:
   - conda create -q -n test-env python=$TRAVIS_PYTHON_VERSION
   - source activate test-env
   # install all dependencies TODO would be nice not to hard-code this, but get from meta.yml
-  - conda install -c conda-forge libgcc
+  # - conda install -c conda-forge libgcc
   - conda install -c conda-forge xtensor=0.15.1
   - conda install -c conda-forge xtensor-python
   - conda install -c conda-forge boost c-blosc zlib bzip2

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_script:
   - conda create -q -n test-env python=$TRAVIS_PYTHON_VERSION
   - source activate test-env
   # install all dependencies TODO would be nice not to hard-code this, but get from meta.yml
+  - conda install -c conda-forge libgcc
   - conda install -c conda-forge xtensor=0.15.1
   - conda install -c conda-forge xtensor-python
   - conda install -c conda-forge boost c-blosc zlib bzip2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # TODO osx
 os: linux
 dist: trusty
+sudo: required
 language: python
 python:
   - "2.7"
@@ -11,6 +12,11 @@ addons:
     update: true
 
 before_script:
+  # get gcc 5
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update
+  - sudo apt-get -y install gcc-5 g++-5
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5
   # TODO conda 2 for python 2.7
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
@@ -24,11 +30,11 @@ before_script:
   - source activate test-env
   # install all dependencies TODO would be nice not to hard-code this, but get from meta.yml
   # - conda install -c conda-forge libgcc
+  # - conda install -c psi4 gcc-5
   - conda install -c conda-forge xtensor=0.15.1
   - conda install -c conda-forge xtensor-python
   - conda install -c conda-forge boost c-blosc zlib bzip2
   - conda install -c anaconda cmake
-  - conda install -c psi4 gcc-5
   - conda install six
 
 script:
@@ -44,8 +50,8 @@ script:
   ###############################################
   # setup compiler
   ###############################################
-  - export CXX="$ENV_BIN/g++"
-  - export CC="$ENV_BIN/gcc"
+  - export CXX=/usr/bin/g++
+  - export CC=/usr/bin/gcc
 
   ###############################################
   # configure cmake

--- a/include/z5/multiarray/broadcast.hxx
+++ b/include/z5/multiarray/broadcast.hxx
@@ -2,24 +2,21 @@
 
 #include "z5/dataset.hxx"
 #include "z5/multiarray/xtensor_access.hxx"
+#include "z5/util/threadpool.hxx"
+
 #include "xtensor/xeval.hpp"
 
 
 namespace z5 {
 namespace multiarray {
 
-    template<typename T, typename ITER>
-    void writeScalar(const Dataset & ds, ITER roiBeginIter, ITER roiShapeIter, const T val) {
 
-        // get the offset and shape of the request and check if it is valid
-        types::ShapeType offset(roiBeginIter, roiBeginIter+ds.dimension());
-        types::ShapeType shape(roiShapeIter, roiShapeIter+ds.dimension());
-        ds.checkRequestShape(offset, shape);
-        ds.checkRequestType(typeid(T));
-
-        // get the chunks that are involved in this request
-        std::vector<types::ShapeType> chunkRequests;
-        ds.getChunkRequests(offset, shape, chunkRequests);
+    template<typename T>
+    void writeScalarSingleThreaded(const Dataset & ds,
+                                   const types::ShapeType & offset,
+                                   const types::ShapeType & shape,
+                                   const T val,
+                                   const std::vector<types::ShapeType> & chunkRequests) {
 
         types::ShapeType offsetInRequest, requestShape, chunkShape, offsetInChunk;
         // out buffer holding data for a single chunk
@@ -72,10 +69,107 @@ namespace multiarray {
     }
 
 
+    template<typename T>
+    void writeScalarMultiThreaded(const Dataset & ds,
+                                  const types::ShapeType & offset,
+                                  const types::ShapeType & shape,
+                                  const T val,
+                                  const std::vector<types::ShapeType> & chunkRequests,
+                                  const int numberOfThreads) {
+
+        // construct threadpool and make a buffer for each thread
+        util::ThreadPool tp(numberOfThreads);
+        const int nThreads = tp.nThreads();
+
+        // out buffer holding data for a single chunk
+        size_t chunkSize = ds.maxChunkSize();
+        typedef std::vector<T> Buffer;
+        std::vector<Buffer> threadBuffers(nThreads, Buffer(chunkSize, val));
+
+        // write scalar to the chunks in parallel
+        const size_t nChunks = chunkRequests.size();
+        util::parallel_foreach(tp, nChunks, [&](const int tId, const size_t chunkIndex){
+
+            const auto & chunkId = chunkRequests[chunkIndex];
+            auto & buffer = threadBuffers[tId];
+
+            types::ShapeType offsetInRequest, requestShape, chunkShape, offsetInChunk;
+            bool completeOvlp = ds.getCoordinatesInRequest(chunkId,
+                                                           offset,
+                                                           shape,
+                                                           offsetInRequest,
+                                                           requestShape,
+                                                           offsetInChunk);
+
+
+            ds.getChunkShape(chunkId, chunkShape);
+            chunkSize = std::accumulate(chunkShape.begin(), chunkShape.end(), 1, std::multiplies<size_t>());
+
+            // reshape buffer if necessary
+            if(buffer.size() != chunkSize) {
+                buffer.resize(chunkSize, val);
+            }
+
+            // request and chunk overlap completely
+            // -> we can write the whole chunk
+            if(completeOvlp) {
+                ds.writeChunk(chunkId, &buffer[0]);
+            }
+
+            // request and chunk overlap only partially
+            // -> we can only write partial data and need
+            // to preserve the data that will not be written
+            else {
+                // load the current data into the buffer
+                ds.readChunk(chunkId, &buffer[0]);
+                // overwrite the data that is covered by the request
+                auto fullBuffView = xt::adapt(buffer, chunkShape);
+                xt::slice_vector bufSlice(fullBuffView);
+                sliceFromRoi(bufSlice, offsetInChunk, requestShape);
+                auto bufView = xt::dynamic_view(fullBuffView, bufSlice);
+                bufView = val;
+                ds.writeChunk(chunkId, &buffer[0]);
+
+                // need to reset the buffer to our fill value
+                std::fill(buffer.begin(), buffer.end(), val);
+            }
+        });
+    }
+
+    template<typename T, typename ITER>
+    void writeScalar(const Dataset & ds,
+                     ITER roiBeginIter,
+                     ITER roiShapeIter,
+                     const T val,
+                     const int numberOfThreads=1) {
+
+        // get the offset and shape of the request and check if it is valid
+        types::ShapeType offset(roiBeginIter, roiBeginIter+ds.dimension());
+        types::ShapeType shape(roiShapeIter, roiShapeIter+ds.dimension());
+        ds.checkRequestShape(offset, shape);
+        ds.checkRequestType(typeid(T));
+
+        // get the chunks that are involved in this request
+        std::vector<types::ShapeType> chunkRequests;
+        ds.getChunkRequests(offset, shape, chunkRequests);
+
+        // write scalar single or multi-threaded
+        if(numberOfThreads == 1) {
+            writeScalarSingleThreaded<T>(ds, offset, shape, val, chunkRequests);
+        } else {
+            writeScalarMultiThreaded<T>(ds, offset, shape, val, chunkRequests, numberOfThreads);
+        }
+    }
+
+
     // unique ptr API
     template<typename T, typename ITER>
-    inline void writeScalar(std::unique_ptr<Dataset> & ds, ITER roiBeginIter, ITER roiShapeIter, const T val) {
-       writeScalar(*ds, roiBeginIter, roiShapeIter, val);
+    inline void writeScalar(std::unique_ptr<Dataset> & ds,
+                            ITER roiBeginIter,
+                            ITER roiShapeIter,
+                            const T val,
+                            const int numberOfThreads=1) {
+       writeScalar(*ds, roiBeginIter, roiShapeIter, val, numberOfThreads);
     }
 }
 }

--- a/include/z5/multiarray/xtensor_access.hxx
+++ b/include/z5/multiarray/xtensor_access.hxx
@@ -3,6 +3,7 @@
 #include "z5/dataset.hxx"
 #include "z5/types/types.hxx"
 #include "z5/multiarray/xtensor_util.hxx"
+#include "z5/util/threadpool.hxx"
 
 #include "xtensor/xarray.hpp"
 #include "xtensor/xstrided_view.hpp"
@@ -14,22 +15,14 @@
 namespace z5 {
 namespace multiarray {
 
-    template<typename T, typename ARRAY, typename ITER>
-    inline void readSubarray(const Dataset & ds, xt::xexpression<ARRAY> & outExpression, ITER roiBeginIter) {
-
+    template<typename T, typename ARRAY>
+    inline void readSubarraySingleThreaded(const Dataset & ds,
+                                           xt::xexpression<ARRAY> & outExpression,
+                                           const types::ShapeType & offset,
+                                           const types::ShapeType & shape,
+                                           const std::vector<types::ShapeType> & chunkRequests) {
         // need to cast to the actual xtensor implementation
         auto & out = outExpression.derived_cast();
-
-        // get the offset and shape of the request and check if it is valid
-        types::ShapeType offset(roiBeginIter, roiBeginIter+out.dimension());
-        types::ShapeType shape(out.shape().begin(), out.shape().end());
-        ds.checkRequestShape(offset, shape);
-        ds.checkRequestType(typeid(T));
-
-        // get the chunks that are involved in this request
-        std::vector<types::ShapeType> chunkRequests;
-
-        ds.getChunkRequests(offset, shape, chunkRequests);
 
         types::ShapeType offsetInRequest, requestShape, chunkShape;
         types::ShapeType offsetInChunk;
@@ -83,20 +76,97 @@ namespace multiarray {
                 // but this would be kind of hard and premature optimization
                 view = bufView;
             }
-
         }
     }
 
 
-    template<typename T, typename ARRAY, typename ITER>
-    void writeSubarray(const Dataset & ds, const xt::xexpression<ARRAY> & inExpression, ITER roiBeginIter) {
+    template<typename T, typename ARRAY>
+    inline void readSubarrayMultiThreaded(const Dataset & ds,
+                                          xt::xexpression<ARRAY> & outExpression,
+                                          const types::ShapeType & offset,
+                                          const types::ShapeType & shape,
+                                          const std::vector<types::ShapeType> & chunkRequests,
+                                          const int numberOfThreads) {
+        // need to cast to the actual xtensor implementation
+        auto & out = outExpression.derived_cast();
 
-        const auto & in = inExpression.derived_cast();
+        // construct threadpool and make a buffer for each thread
+        util::ThreadPool tp(numberOfThreads);
+        const int nThreads = tp.nThreads();
+
+        size_t chunkSize = ds.maxChunkSize();
+        typedef std::vector<T> Buffer;
+        std::vector<Buffer> threadBuffers(nThreads, Buffer(chunkSize));
+
+        // read the chunks in parallel
+        const size_t nChunks = chunkRequests.size();
+        util::parallel_foreach(tp, nChunks, [&](const int tId, const size_t chunkIndex){
+
+            const auto & chunkId = chunkRequests[chunkIndex];
+            auto & buffer = threadBuffers[tId];
+
+            types::ShapeType offsetInRequest, requestShape, chunkShape;
+            types::ShapeType offsetInChunk;
+
+            //std::cout << "Reading chunk " << chunkId << std::endl;
+            bool completeOvlp = ds.getCoordinatesInRequest(chunkId,
+                                                           offset,
+                                                           shape,
+                                                           offsetInRequest,
+                                                           requestShape,
+                                                           offsetInChunk);
+
+            // get the view in our array
+            xt::slice_vector offsetSlice(out);
+            sliceFromRoi(offsetSlice, offsetInRequest, requestShape);
+            auto view = xt::dynamic_view(out, offsetSlice);
+
+            // get the current chunk-shape and resize the buffer if necessary
+            ds.getChunkShape(chunkId, chunkShape);
+            chunkSize = std::accumulate(chunkShape.begin(), chunkShape.end(), 1, std::multiplies<size_t>());
+            if(chunkSize != buffer.size()) {
+                buffer.resize(chunkSize);
+            }
+
+            // read the current chunk into the buffer
+            ds.readChunk(chunkId, &buffer[0]);
+
+            // request and chunk completely overlap
+            // -> we can read all the data from the chunk
+            if(completeOvlp) {
+                copyBufferToView(buffer, view, out.strides());
+                //auto bufferView = xt::adapt(buffer, view.shape());
+                //view = bufferView;
+            }
+            // request and chunk overlap only partially
+            // -> we can read the chunk data only partially
+            else {
+                // get a view to the part of the buffer we are interested in
+                auto fullBuffView = xt::adapt(buffer, chunkShape);
+                xt::slice_vector bufSlice(fullBuffView);
+                sliceFromRoi(bufSlice, offsetInChunk, requestShape);
+                auto bufView = xt::dynamic_view(fullBuffView, bufSlice);
+
+                // could also implement smart view for this,
+                // but this would be kind of hard and premature optimization
+                view = bufView;
+            }
+        });
+    }
+
+
+    template<typename T, typename ARRAY, typename ITER>
+    inline void readSubarray(const Dataset & ds,
+                             xt::xexpression<ARRAY> & outExpression,
+                             ITER roiBeginIter,
+                             const int numberOfThreads=1) {
+
+        // need to cast to the actual xtensor implementation
+        auto & out = outExpression.derived_cast();
 
         // get the offset and shape of the request and check if it is valid
-        types::ShapeType offset(roiBeginIter, roiBeginIter+in.dimension());
-        types::ShapeType shape(in.shape().begin(), in.shape().end());
-
+        types::ShapeType offset(roiBeginIter, roiBeginIter+out.dimension());
+        types::ShapeType shape(out.shape().begin(), out.shape().end());
         ds.checkRequestShape(offset, shape);
         ds.checkRequestType(typeid(T));
 
@@ -104,6 +174,23 @@ namespace multiarray {
         std::vector<types::ShapeType> chunkRequests;
         ds.getChunkRequests(offset, shape, chunkRequests);
 
+        // read single or multi-threaded
+        if(numberOfThreads == 1) {
+            readSubarraySingleThreaded<T>(ds, out, offset, shape, chunkRequests);
+        } else {
+            readSubarrayMultiThreaded<T>(ds, out, offset, shape, chunkRequests, numberOfThreads);
+        }
+    }
+
+
+    template<typename T, typename ARRAY>
+    inline void writeSubarraySingleThreaded(const Dataset & ds,
+                                            const xt::xexpression<ARRAY> & inExpression,
+                                            const types::ShapeType & offset,
+                                            const types::ShapeType & shape,
+                                            const std::vector<types::ShapeType> & chunkRequests) {
+
+        const auto & in = inExpression.derived_cast();
         types::ShapeType offsetInRequest, requestShape, chunkShape;
         types::ShapeType offsetInChunk;
 
@@ -158,15 +245,124 @@ namespace multiarray {
     }
 
 
-    // unique ptr API
-    template<typename T, typename ARRAY, typename ITER>
-    inline void readSubarray(std::unique_ptr<Dataset> & ds, xt::xexpression<ARRAY> & out, ITER roiBeginIter) {
-       readSubarray<T>(*ds, out, roiBeginIter);
+    template<typename T, typename ARRAY>
+    inline void writeSubarrayMultiThreaded(const Dataset & ds,
+                                           const xt::xexpression<ARRAY> & inExpression,
+                                           const types::ShapeType & offset,
+                                           const types::ShapeType & shape,
+                                           const std::vector<types::ShapeType> & chunkRequests,
+                                           const int numberOfThreads) {
+
+        const auto & in = inExpression.derived_cast();
+
+        // construct threadpool and make a buffer for each thread
+        util::ThreadPool tp(numberOfThreads);
+        const int nThreads = tp.nThreads();
+
+        size_t chunkSize = ds.maxChunkSize();
+        typedef std::vector<T> Buffer;
+        std::vector<Buffer> threadBuffers(nThreads, Buffer(chunkSize));
+
+        // write the chunks in parallel
+        const size_t nChunks = chunkRequests.size();
+        util::parallel_foreach(tp, nChunks, [&](const int tId, const size_t chunkIndex){
+
+            const auto & chunkId = chunkRequests[chunkIndex];
+            auto & buffer = threadBuffers[tId];
+
+            types::ShapeType offsetInRequest, requestShape, chunkShape;
+            types::ShapeType offsetInChunk;
+
+            bool completeOvlp = ds.getCoordinatesInRequest(chunkId, offset, shape, offsetInRequest, requestShape, offsetInChunk);
+            ds.getChunkShape(chunkId, chunkShape);
+            chunkSize = std::accumulate(chunkShape.begin(), chunkShape.end(), 1, std::multiplies<size_t>());
+
+            // get the view into the in-array
+            xt::slice_vector offsetSlice(in);
+            sliceFromRoi(offsetSlice, offsetInRequest, requestShape);
+            const auto view = xt::dynamic_view(in, offsetSlice);
+
+            // resize buffer if necessary
+            if(chunkSize != buffer.size()) {
+                buffer.resize(chunkSize);
+            }
+
+            // request and chunk overlap completely
+            // -> we can write the whole chunk
+            if(completeOvlp) {
+                copyViewToBuffer(view, buffer, in.strides());
+                ds.writeChunk(chunkId, &buffer[0]);
+            }
+
+            // request and chunk overlap only partially
+            // -> we can only write partial data and need
+            // to preserve the data that will not be written
+            else {
+                // load the current data into the buffer
+                ds.readChunk(chunkId, &buffer[0]);
+
+                // overwrite the data that is covered by the request
+                auto fullBuffView = xt::adapt(buffer, chunkShape);
+                xt::slice_vector bufSlice(fullBuffView);
+                sliceFromRoi(bufSlice, offsetInChunk, requestShape);
+                auto bufView = xt::dynamic_view(fullBuffView, bufSlice);
+
+                // could also implement smart view for this,
+                // but this would be kind of hard and premature optimization
+                bufView = view;
+
+                // write the chunk
+                ds.writeChunk(chunkId, &buffer[0]);
+            }
+        });
     }
 
+
     template<typename T, typename ARRAY, typename ITER>
-    inline void writeSubarray(std::unique_ptr<Dataset> & ds, const xt::xexpression<ARRAY> & in, ITER roiBeginIter) {
-        writeSubarray<T>(*ds, in, roiBeginIter);
+    inline void writeSubarray(const Dataset & ds,
+                              const xt::xexpression<ARRAY> & inExpression,
+                              ITER roiBeginIter,
+                              const int numberOfThreads=1) {
+
+        const auto & in = inExpression.derived_cast();
+
+        // get the offset and shape of the request and check if it is valid
+        types::ShapeType offset(roiBeginIter, roiBeginIter+in.dimension());
+        types::ShapeType shape(in.shape().begin(), in.shape().end());
+
+        ds.checkRequestShape(offset, shape);
+        ds.checkRequestType(typeid(T));
+
+        // get the chunks that are involved in this request
+        std::vector<types::ShapeType> chunkRequests;
+        ds.getChunkRequests(offset, shape, chunkRequests);
+
+        // write data multi or single threaded
+        if(numberOfThreads == 1) {
+            writeSubarraySingleThreaded<T>(ds, in, offset, shape, chunkRequests);
+        } else {
+            writeSubarrayMultiThreaded<T>(ds, in, offset, shape, chunkRequests, numberOfThreads);
+        }
+
+    }
+
+
+    // unique ptr API
+    template<typename T, typename ARRAY, typename ITER>
+    inline void readSubarray(std::unique_ptr<Dataset> & ds,
+                             xt::xexpression<ARRAY> & out,
+                             ITER roiBeginIter,
+                             const int numberOfThreads=1) {
+       readSubarray<T>(*ds, out, roiBeginIter, numberOfThreads);
+    }
+
+
+    template<typename T, typename ARRAY, typename ITER>
+    inline void writeSubarray(std::unique_ptr<Dataset> & ds,
+                              const xt::xexpression<ARRAY> & in,
+                              ITER roiBeginIter,
+                              const int numberOfThreads=1) {
+        writeSubarray<T>(*ds, in, roiBeginIter, numberOfThreads);
     }
 
 

--- a/include/z5/types/types.hxx
+++ b/include/z5/types/types.hxx
@@ -15,7 +15,7 @@ namespace types {
     // Coordinates
     //
 
-    // TODO implement class that inherits froms std::vector and overloads useful operators (+, -, etc.)
+    // TODO implement class that inherits from std::vector and overloads useful operators (+, -, etc.)
     // TODO rename to coordinate type
     // type for array shapes
     typedef std::vector<size_t> ShapeType;
@@ -24,7 +24,6 @@ namespace types {
     // Datatypes
     //
 
-    // TODO add bool ?
     // dtype enum and map
     enum Datatype {
         int8, int16, int32, int64,

--- a/include/z5/util/threadpool.hxx
+++ b/include/z5/util/threadpool.hxx
@@ -1,0 +1,643 @@
+#pragma once
+#include <functional>
+#include <thread>
+#include <atomic>
+#include <vector>
+#include <future>
+#include <mutex>
+#include <queue>
+#include <condition_variable>
+#include <stdexcept>
+#include <cmath>
+
+#include <boost/iterator/transform_iterator.hpp>
+#include <boost/iterator/counting_iterator.hpp>
+
+
+/*
+ * Copied and slightly adapted from
+ * nifty/include/nifty/parallel/threadpool.hxx
+ */
+
+
+
+namespace z5 {
+namespace util {
+
+/** \addtogroup ParallelProcessing Functions and classes for parallel processing.
+*/
+
+//@{
+
+    /**\brief Option base class for parallel algorithms.
+
+        <b>\#include</b> \<nifty/parallel/threadpool.hxx\><br>
+        Namespace: nifty::parallel
+    */
+class ParallelOptions
+{
+  public:
+
+        /** Constants for special settings.
+        */
+    enum {
+        Auto       = -1, ///< Determine number of threads automatically (from <tt>std::thread::hardware_concurrency()</tt>)
+        Nice       = -2, ///< Use half as many threads as <tt>Auto</tt> would.
+        NoThreads  =  0  ///< Switch off multi-threading (i.e. execute tasks sequentially)
+    };
+
+    ParallelOptions(int nT = Auto)
+    :   numThreads_(actualNumThreads(nT))
+    {}
+
+        /** \brief Get desired number of threads.
+
+            <b>Note:</b> This function may return 0, which means that multi-threading
+            shall be switched off entirely. If an algorithm receives this value,
+            it should revert to a sequential implementation. In contrast, if
+            <tt>numThread() == 1</tt>, the parallel algorithm version shall be
+            executed with a single thread.
+        */
+    int getNumThreads() const
+    {
+        return numThreads_;
+    }
+
+        /** \brief Get desired number of threads.
+
+            In contrast to <tt>numThread()</tt>, this will always return a value <tt>>=1</tt>.
+        */
+    int getActualNumThreads() const
+    {
+        return std::max(1,numThreads_);
+    }
+
+        /** \brief Set the number of threads or one of the constants <tt>Auto</tt>,
+                   <tt>Nice</tt> and <tt>NoThreads</tt>.
+
+            Default: <tt>ParallelOptions::Auto</tt> (use system default)
+
+            This setting is ignored if the preprocessor flag <tt>NIFTY_NO_PARALLELISM</tt>
+            is defined. Then, the number of threads is set to 0 and all tasks revert to
+            sequential algorithm implementations. The same can be achieved at runtime
+            by passing <tt>n = 0</tt> to this function. In contrast, passing <tt>n = 1</tt>
+            causes the parallel algorithm versions to be executed with a single thread.
+            Both possibilities are mainly useful for debugging.
+        */
+    ParallelOptions & numThreads(const int n)
+    {
+        numThreads_ = actualNumThreads(n);
+        return *this;
+    }
+
+
+  private:
+        // helper function to compute the actual number of threads
+    static size_t actualNumThreads(const int userNThreads)
+    {
+        #ifdef NIFTY_NO_PARALLELISM
+            return 0;
+        #else
+            return userNThreads >= 0
+                       ? userNThreads
+                       : userNThreads == Nice
+                               ? std::thread::hardware_concurrency() / 2
+                               : std::thread::hardware_concurrency();
+        #endif
+    }
+
+    int numThreads_;
+};
+
+/********************************************************/
+/*                                                      */
+/*                      ThreadPool                      */
+/*                                                      */
+/********************************************************/
+
+    /**\brief Thread pool class to manage a set of parallel workers.
+
+        <b>\#include</b> \<nifty/parallel/threadpool.hxx\><br>
+        Namespace: nifty::parallel
+    */
+class ThreadPool
+{
+  public:
+
+    /** Create a thread pool from ParallelOptions. The constructor just launches
+        the desired number of workers. If the number of threads is zero,
+        no workers are started, and all tasks will be executed in synchronously
+        in the present thread.
+     */
+    ThreadPool(const ParallelOptions & options)
+    :   stop(false),
+        busy(0),
+        processed(0)
+    {
+        init(options);
+    }
+
+    /** Create a thread pool with n threads. The constructor just launches
+        the desired number of workers. If \arg n is <tt>ParallelOptions::Auto</tt>,
+        the number of threads is determined by <tt>std::thread::hardware_concurrency()</tt>.
+        <tt>ParallelOptions::Nice</tt> will create half as many threads.
+        If <tt>n = 0</tt>, no workers are started, and all tasks will be executed
+        synchronously in the present thread. If the preprocessor flag
+        <tt>NIFTY_NO_PARALLELISM</tt> is defined, the number of threads is always set
+        to zero (i.e. synchronous execution), regardless of the value of \arg n. This
+        is useful for debugging.
+     */
+    ThreadPool(const int n)
+    :   stop(false),
+        busy(0),
+        processed(0)
+    {
+        init(ParallelOptions().numThreads(n));
+    }
+
+    /**
+     * The destructor joins all threads.
+     */
+    ~ThreadPool();
+
+    /**
+     * Enqueue a task that will be executed by the thread pool.
+     * The task result can be obtained using the get() function of the returned future.
+     * If the task throws an exception, it will be raised on the call to get().
+     */
+    template<class F>
+    std::future<typename std::result_of<F(int)>::type>  enqueueReturning(F&& f) ;
+
+    /**
+     * Enqueue function for tasks without return value.
+     * This is a special case of the enqueueReturning template function, but
+     * some compilers fail on <tt>std::result_of<F(int)>::type</tt> for void(int) functions.
+     */
+    template<class F>
+    std::future<void> enqueue(F&& f) ;
+
+    /**
+     * Block until all tasks are finished.
+     */
+    void waitFinished()
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex);
+        finish_condition.wait(lock, [this](){ return tasks.empty() && (busy == 0); });
+    }
+
+    /**
+     * Return the number of worker threads.
+     */
+    size_t nThreads() const
+    {
+        return workers.size();
+    }
+
+private:
+
+    // helper function to init the thread pool
+    void init(const ParallelOptions & options);
+
+    // need to keep track of threads so we can join them
+    std::vector<std::thread> workers;
+
+    // the task queue
+    std::queue<std::function<void(int)> > tasks;
+
+    // synchronization
+    std::mutex queue_mutex;
+    std::condition_variable worker_condition;
+    std::condition_variable finish_condition;
+    bool stop;
+    std::atomic<unsigned int> busy, processed;
+};
+
+inline void ThreadPool::init(const ParallelOptions & options)
+{
+    const size_t actualNThreads = options.getNumThreads();
+    for(size_t ti = 0; ti<actualNThreads; ++ti)
+    {
+        workers.emplace_back(
+            [ti,this]
+            {
+                for(;;)
+                {
+                    std::function<void(int)> task;
+                    {
+                        std::unique_lock<std::mutex> lock(this->queue_mutex);
+
+                        // will wait if : stop == false  AND queue is empty
+                        // if stop == true AND queue is empty thread function will return later
+                        //
+                        // so the idea of this wait, is : If where are not in the destructor
+                        // (which sets stop to true, we wait here for new jobs)
+                        this->worker_condition.wait(lock, [this]{ return this->stop || !this->tasks.empty(); });
+                        if(!this->tasks.empty())
+                        {
+                            ++busy;
+                            task = std::move(this->tasks.front());
+                            this->tasks.pop();
+                            lock.unlock();
+                            task(ti);
+                            ++processed;
+                            --busy;
+                            finish_condition.notify_one();
+                        }
+                        else if(stop)
+                        {
+                            return;
+                        }
+                    }
+                }
+            }
+        );
+    }
+}
+
+inline ThreadPool::~ThreadPool()
+{
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex);
+        stop = true;
+    }
+    worker_condition.notify_all();
+    for(std::thread &worker: workers)
+        worker.join();
+}
+
+template<class F>
+inline std::future<typename std::result_of<F(int)>::type>
+ThreadPool::enqueueReturning(F&& f)
+{
+    typedef typename std::result_of<F(int)>::type result_type;
+    typedef std::packaged_task<result_type(int)> PackageType;
+
+    auto task = std::make_shared<PackageType>(f);
+    auto res = task->get_future();
+
+    if(workers.size()>0){
+        {
+            std::unique_lock<std::mutex> lock(queue_mutex);
+
+            // don't allow enqueueing after stopping the pool
+            if(stop)
+                throw std::runtime_error("enqueue on stopped ThreadPool");
+
+            tasks.emplace(
+                [task](int tid)
+                {
+                    (*task)(tid);
+                }
+            );
+        }
+        worker_condition.notify_one();
+    }
+    else{
+        (*task)(0);
+    }
+
+    return res;
+}
+
+template<class F>
+inline std::future<void>
+ThreadPool::enqueue(F&& f)
+{
+    typedef std::packaged_task<void(int)> PackageType;
+
+    auto task = std::make_shared<PackageType>(f);
+    auto res = task->get_future();
+    if(workers.size()>0){
+        {
+            std::unique_lock<std::mutex> lock(queue_mutex);
+
+            // don't allow enqueueing after stopping the pool
+            if(stop)
+                throw std::runtime_error("enqueue on stopped ThreadPool");
+
+            tasks.emplace(
+                [task](int tid)
+                {
+                    (*task)(tid);
+                }
+            );
+        }
+        worker_condition.notify_one();
+    }
+    else{
+        (*task)(0);
+    }
+    return res;
+}
+
+/********************************************************/
+/*                                                      */
+/*                   parallel_foreach                   */
+/*                                                      */
+/********************************************************/
+
+// nItems must be either zero or std::distance(iter, end).
+template<class ITER, class F>
+inline void parallel_foreach_impl(
+    ThreadPool & pool,
+    const std::ptrdiff_t nItems,
+    ITER iter,
+    ITER end,
+    F && f,
+    std::random_access_iterator_tag
+){
+    std::ptrdiff_t workload = std::distance(iter, end);
+
+    // NIFTY_CHECK(workload == nItems || nItems == 0, "parallel_foreach(): Mismatch between num items and begin/end.");
+    const float workPerThread = float(workload)/pool.nThreads();
+    const std::ptrdiff_t chunkedWorkPerThread = std::max<std::ptrdiff_t>(int(workPerThread/3.0f + 0.5f), 1);
+
+    std::vector<std::future<void> > futures;
+    for( ;iter<end; iter+=chunkedWorkPerThread)
+    {
+        const size_t lc = std::min(workload, chunkedWorkPerThread);
+        workload-=lc;
+        futures.emplace_back(
+            pool.enqueue(
+                [&f, iter, lc]
+                (int id)
+                {
+                    for(size_t i=0; i<lc; ++i)
+                        f(id, iter[i]);
+                }
+            )
+        );
+    }
+    for (auto & fut : futures)
+    {
+        fut.get();
+    }
+}
+
+
+
+// nItems must be either zero or std::distance(iter, end).
+template<class ITER, class F>
+inline void parallel_foreach_impl(
+    ThreadPool & pool,
+    const std::ptrdiff_t nItems,
+    ITER iter,
+    ITER end,
+    F && f,
+    std::forward_iterator_tag
+){
+    if (nItems == 0)
+        nItems = std::distance(iter, end);
+
+    std::ptrdiff_t workload = nItems;
+    const float workPerThread = float(workload)/pool.nThreads();
+    const std::ptrdiff_t chunkedWorkPerThread = std::max<std::ptrdiff_t>(int(workPerThread/3.0f+0.5f), 1);
+
+    std::vector<std::future<void> > futures;
+    for(;;)
+    {
+        const size_t lc = std::min(chunkedWorkPerThread, workload);
+        workload -= lc;
+        futures.emplace_back(
+            pool.enqueue(
+                [&f, iter, lc]
+                (int id)
+                {
+                    auto iterCopy = iter;
+                    for(size_t i=0; i<lc; ++i){
+                        f(id, *iterCopy);
+                        ++iterCopy;
+                    }
+                }
+            )
+        );
+        for (size_t i = 0; i < lc; ++i)
+        {
+            ++iter;
+            if (iter == end)
+            {
+                // NIFTY_CHECK_OP(workload, ==, 0, "parallel_foreach(): Mismatch between num items and begin/end.");
+                break;
+            }
+        }
+        if(workload==0)
+            break;
+    }
+    for (auto & fut : futures)
+        fut.get();
+}
+
+
+
+// nItems must be either zero or std::distance(iter, end).
+template<class ITER, class F>
+inline void parallel_foreach_impl(
+    ThreadPool & pool,
+    const std::ptrdiff_t nItems,
+    ITER iter,
+    ITER end,
+    F && f,
+    std::input_iterator_tag
+){
+    size_t num_items = 0;
+    std::vector<std::future<void> > futures;
+    for (; iter != end; ++iter)
+    {
+        auto item = *iter;
+        futures.emplace_back(
+            pool.enqueue(
+                [&f, &item](int id){
+                    f(id, item);
+                }
+            )
+        );
+        ++num_items;
+    }
+    // NIFTY_CHECK(num_items == nItems || nItems == 0, "parallel_foreach(): Mismatch between num items and begin/end.");
+    for (auto & fut : futures)
+        fut.get();
+}
+
+// Runs foreach on a single thread.
+// Used for API compatibility when the numbe of threads is 0.
+template<class ITER, class F>
+inline void parallel_foreach_single_thread(
+    ITER begin,
+    ITER end,
+    F && f,
+    const std::ptrdiff_t nItems = 0
+){
+    size_t n = 0;
+    for (; begin != end; ++begin)
+    {
+        f(0, *begin);
+        ++n;
+    }
+    // NIFTY_CHECK(n == nItems || nItems == 0, "parallel_foreach(): Mismatch between num items and begin/end.");
+}
+
+/** \brief Apply a functor to all items in a range in parallel.
+
+    Create a thread pool (or use an existing one) to apply the functor \arg f
+    to all items in the range <tt>[begin, end)</tt> in parallel. \arg f must
+    be callable with two arguments of type <tt>size_t</tt> and <tt>T</tt>, where
+    the first argument is the thread index (starting at 0) and T is convertible
+    from the iterator's <tt>reference_type</tt> (i.e. the result of <tt>*begin</tt>).
+
+    If the iterators are forward iterators (<tt>std::forward_iterator_tag</tt>), you
+    can provide the optional argument <tt>nItems</tt> to avoid the a
+    <tt>std::distance(begin, end)</tt> call to compute the range's length.
+
+    Parameter <tt>nThreads</tt> controls the number of threads. <tt>parallel_foreach</tt>
+    will split the work into about three times as many parallel tasks.
+    If <tt>nThreads = ParallelOptions::Auto</tt>, the number of threads is set to
+    the machine default (<tt>std::thread::hardware_concurrency()</tt>).
+
+    If <tt>nThreads = 0</tt>, the function will not use threads,
+    but will call the functor sequentially. This can also be enforced by setting the
+    preprocessor flag <tt>NIFTY_NO_PARALLELISM</tt>, ignoring the value of
+    <tt>nThreads</tt> (useful for debugging).
+
+    <b> Declarations:</b>
+
+    \code
+    namespace nifty {
+    namespace parallel{
+        // pass the desired number of threads or ParallelOptions::Auto
+        // (creates an internal thread pool accordingly)
+        template<class ITER, class F>
+        void parallel_foreach(int64_t nThreads,
+                              ITER begin, ITER end,
+                              F && f,
+                              const uint64_t nItems = 0);
+
+        // use an existing thread pool
+        template<class ITER, class F>
+        void parallel_foreach(ThreadPool & pool,
+                              ITER begin, ITER end,
+                              F && f,
+                              const uint64_t nItems = 0);
+
+        // pass the integers from 0 ... (nItems-1) to the functor f,
+        // using the given number of threads or ParallelOptions::Auto
+        template<class F>
+        void parallel_foreach(int64_t nThreads,
+                              uint64_t nItems,
+                              F && f);
+
+        // likewise with an existing thread pool
+        template<class F>
+        void parallel_foreach(ThreadPool & threadpool,
+                              uint64_t nItems,
+                              F && f);
+    }
+    }
+    \endcode
+
+    <b>Usage:</b>
+
+    \code
+    #include <iostream>
+    #include <algorithm>
+    #include <vector>
+    #include <nifty/parallel/threadpool.hxx>
+
+    using namespace std;
+    using namespace nifty::parallel;
+
+    int main()
+    {
+        size_t const n_threads = 4;
+        size_t const n = 2000;
+        vector<int> input(n);
+
+        auto iter = input.begin(),
+             end  = input.end();
+
+        // fill input with 0, 1, 2, ...
+        iota(iter, end, 0);
+
+        // compute the sum of the elements in the input vector.
+        // (each thread computes the partial sum of the items it sees
+        //  and stores the sum at the appropriate index of 'results')
+        vector<int> results(n_threads, 0);
+        parallel_foreach(n_threads, iter, end,
+            // the functor to be executed, defined as a lambda function
+            // (first argument: thread ID, second argument: result of *iter)
+            [&results](size_t thread_id, int items)
+            {
+                results[thread_id] += items;
+            }
+        );
+
+        // collect the partial sums of all threads
+        int sum = accumulate(results.begin(), results.end(), 0);
+
+        cout << "The sum " << sum << " should be equal to " << (n*(n-1))/2 << endl;
+    }
+    \endcode
+ */
+//doxygen_overloaded_function(template <...> void parallel_foreach)
+
+template<class ITER, class F>
+inline void parallel_foreach(
+    ThreadPool & pool,
+    ITER begin,
+    ITER end,
+    F && f,
+    const std::ptrdiff_t nItems = 0)
+{
+    if(pool.nThreads()>1)
+    {
+        parallel_foreach_impl(pool,nItems, begin, end, f,
+            typename std::iterator_traits<ITER>::iterator_category());
+    }
+    else
+    {
+        parallel_foreach_single_thread(begin, end, f, nItems);
+    }
+}
+
+template<class ITER, class F>
+inline void parallel_foreach(
+    int64_t nThreads,
+    ITER begin,
+    ITER end,
+    F && f,
+    const std::ptrdiff_t nItems = 0)
+{
+
+    ThreadPool pool(nThreads);
+    parallel_foreach(pool, begin, end, f, nItems);
+}
+
+template<class F>
+inline void parallel_foreach(
+    int64_t nThreads,
+    std::ptrdiff_t nItems,
+    F && f)
+{
+    auto beginIter  = boost::counting_iterator<int64_t>(0);
+    auto endIter  = boost::counting_iterator<int64_t>(nItems);
+
+    parallel_foreach(nThreads, beginIter, endIter, f, nItems);
+}
+
+
+template<class F>
+inline void parallel_foreach(
+    ThreadPool & threadpool,
+    std::ptrdiff_t nItems,
+    F && f)
+{
+
+    auto beginIter  = boost::counting_iterator<int64_t>(0);
+    auto endIter  = boost::counting_iterator<int64_t>(nItems);
+
+    parallel_foreach(threadpool, beginIter, endIter, f, nItems);
+}
+
+//@}
+
+} // namespace parallel
+} // namespace nifty

--- a/src/python/lib/dataset.cxx
+++ b/src/python/lib/dataset.cxx
@@ -18,13 +18,19 @@ namespace py = pybind11;
 namespace z5 {
 
     template<class T>
-    inline void writePySubarray(const Dataset & ds, const xt::pyarray<T> & in, const std::vector<size_t> & roiBegin) {
-        multiarray::writeSubarray<T>(ds, in, roiBegin.begin());
+    inline void writePySubarray(const Dataset & ds,
+                                const xt::pyarray<T> & in,
+                                const std::vector<size_t> & roiBegin,
+                                const int numberOfThreads) {
+        multiarray::writeSubarray<T>(ds, in, roiBegin.begin(), numberOfThreads);
     }
 
     template<class T>
-    inline void readPySubarray(const Dataset & ds, xt::pyarray<T> & out, const std::vector<size_t> & roiBegin) {
-        multiarray::readSubarray<T>(ds, out, roiBegin.begin());
+    inline void readPySubarray(const Dataset & ds,
+                               xt::pyarray<T> & out,
+                               const std::vector<size_t> & roiBegin,
+                               const int numberOfThreads) {
+        multiarray::readSubarray<T>(ds, out, roiBegin.begin(), numberOfThreads);
     }
 
     template<class T>
@@ -50,19 +56,28 @@ namespace z5 {
         // export writing subarrays
         module.def("write_subarray",
                    &writePySubarray<T>,
-                   py::arg("ds"), py::arg("in").noconvert(), py::arg("roi_begin"),
+                   py::arg("ds"),
+                   py::arg("in").noconvert(),
+                   py::arg("roi_begin"),
+                   py::arg("n_threads")=1,
                    py::call_guard<py::gil_scoped_release>());
 
         // export reading subarrays
         module.def("read_subarray",
                    &readPySubarray<T>,
-                   py::arg("ds"), py::arg("out").noconvert(), py::arg("roi_begin"),
+                   py::arg("ds"),
+                   py::arg("out").noconvert(),
+                   py::arg("roi_begin"),
+                   py::arg("n_threads")=1,
                    py::call_guard<py::gil_scoped_release>());
 
         // export writing scalars
         module.def("write_scalar",
                    &writePyScalar<T>,
-                   py::arg("ds"), py::arg("roi_begin"), py::arg("roi_shape"), py::arg("val").noconvert(),
+                   py::arg("ds"),
+                   py::arg("roi_begin"),
+                   py::arg("roi_shape"),
+                   py::arg("val").noconvert(),
                    py::call_guard<py::gil_scoped_release>());
 
         // export conversions

--- a/src/python/lib/dataset.cxx
+++ b/src/python/lib/dataset.cxx
@@ -38,12 +38,12 @@ namespace z5 {
                               const std::vector<size_t> & roiBegin,
                               const std::vector<size_t> & roiShape,
                               const T val) {
-        multiarray::writeScalar(ds, roiBegin.begin(), roiShape.begin(), val);
+        multiarray::writeScalar<T>(ds, roiBegin.begin(), roiShape.begin(), val);
     }
 
     template<class T>
     inline xt::pytensor<char, 1> convertPyArrayToFormat(const Dataset & ds,
-                                       const xt::pyarray<T> & in) {
+                                                        const xt::pyarray<T> & in) {
         xt::pytensor<char, 1> out = xt::zeros<char>({1});
         multiarray::convertArrayToFormat<T>(ds, in, out);
         return out;
@@ -69,15 +69,6 @@ namespace z5 {
                    py::arg("out").noconvert(),
                    py::arg("roi_begin"),
                    py::arg("n_threads")=1,
-                   py::call_guard<py::gil_scoped_release>());
-
-        // export writing scalars
-        module.def("write_scalar",
-                   &writePyScalar<T>,
-                   py::arg("ds"),
-                   py::arg("roi_begin"),
-                   py::arg("roi_shape"),
-                   py::arg("val").noconvert(),
                    py::call_guard<py::gil_scoped_release>());
 
         // export conversions
@@ -175,6 +166,48 @@ namespace z5 {
         // float types
         exportIoT<float>(module);
         exportIoT<double>(module);
+
+        // export writing scalars
+        // The overloads cannot be properly resolved,
+        // that's why we give the datatype as additional argument
+        // and then cast to the correct type
+        module.def("write_scalar", [](const Dataset & ds,
+                                      const std::vector<size_t> & roiBegin,
+                                      const std::vector<size_t> & roiShape,
+                                      const double val,
+                                      const std::string & dtype) {
+                    auto internalDtype = types::Datatypes::n5ToDtype().at(dtype);
+                    switch(internalDtype) {
+                        case types::Datatype::int8 : writePyScalar<int8_t>(ds, roiBegin, roiShape, static_cast<int8_t>(val));
+                                                     break;
+                        case types::Datatype::int16 : writePyScalar<int16_t>(ds, roiBegin, roiShape, static_cast<int16_t>(val));
+                                                     break;
+                        case types::Datatype::int32 : writePyScalar<int32_t>(ds, roiBegin, roiShape, static_cast<int32_t>(val));
+                                                     break;
+                        case types::Datatype::int64 : writePyScalar<int64_t>(ds, roiBegin, roiShape, static_cast<int64_t>(val));
+                                                     break;
+                        case types::Datatype::uint8 : writePyScalar<uint8_t>(ds, roiBegin, roiShape, static_cast<uint8_t>(val));
+                                                     break;
+                        case types::Datatype::uint16 : writePyScalar<uint16_t>(ds, roiBegin, roiShape, static_cast<uint16_t>(val));
+                                                     break;
+                        case types::Datatype::uint32 : writePyScalar<uint32_t>(ds, roiBegin, roiShape, static_cast<uint32_t>(val));
+                                                     break;
+                        case types::Datatype::uint64 : writePyScalar<uint64_t>(ds, roiBegin, roiShape, static_cast<uint64_t>(val));
+                                                     break;
+                        case types::Datatype::float32 : writePyScalar<float>(ds, roiBegin, roiShape, static_cast<float>(val));
+                                                        break;
+                        case types::Datatype::float64 : writePyScalar<double>(ds, roiBegin, roiShape, static_cast<double>(val));
+                                                        break;
+                        default: throw(std::runtime_error("Invalid datatype"));
+
+                    }
+                },py::arg("ds"),
+                  py::arg("roi_begin"),
+                  py::arg("roi_shape"),
+                  py::arg("val"),
+                  py::arg("dtype"),
+                  py::call_guard<py::gil_scoped_release>());
+
     }
 
 

--- a/src/python/lib/dataset.cxx
+++ b/src/python/lib/dataset.cxx
@@ -37,8 +37,9 @@ namespace z5 {
     inline void writePyScalar(const Dataset & ds,
                               const std::vector<size_t> & roiBegin,
                               const std::vector<size_t> & roiShape,
-                              const T val) {
-        multiarray::writeScalar<T>(ds, roiBegin.begin(), roiShape.begin(), val);
+                              const T val,
+                              const int numberOfThreads) {
+        multiarray::writeScalar<T>(ds, roiBegin.begin(), roiShape.begin(), val, numberOfThreads);
     }
 
     template<class T>
@@ -175,28 +176,49 @@ namespace z5 {
                                       const std::vector<size_t> & roiBegin,
                                       const std::vector<size_t> & roiShape,
                                       const double val,
-                                      const std::string & dtype) {
+                                      const std::string & dtype,
+                                      const int numberOfThreads) {
                     auto internalDtype = types::Datatypes::n5ToDtype().at(dtype);
                     switch(internalDtype) {
-                        case types::Datatype::int8 : writePyScalar<int8_t>(ds, roiBegin, roiShape, static_cast<int8_t>(val));
+                        case types::Datatype::int8 : writePyScalar<int8_t>(ds, roiBegin, roiShape,
+                                                                           static_cast<int8_t>(val),
+                                                                           numberOfThreads);
                                                      break;
-                        case types::Datatype::int16 : writePyScalar<int16_t>(ds, roiBegin, roiShape, static_cast<int16_t>(val));
+                        case types::Datatype::int16 : writePyScalar<int16_t>(ds, roiBegin, roiShape,
+                                                                             static_cast<int16_t>(val),
+                                                                             numberOfThreads);
                                                      break;
-                        case types::Datatype::int32 : writePyScalar<int32_t>(ds, roiBegin, roiShape, static_cast<int32_t>(val));
+                        case types::Datatype::int32 : writePyScalar<int32_t>(ds, roiBegin, roiShape,
+                                                                             static_cast<int32_t>(val),
+                                                                             numberOfThreads);
                                                      break;
-                        case types::Datatype::int64 : writePyScalar<int64_t>(ds, roiBegin, roiShape, static_cast<int64_t>(val));
+                        case types::Datatype::int64 : writePyScalar<int64_t>(ds, roiBegin, roiShape,
+                                                                             static_cast<int64_t>(val),
+                                                                             numberOfThreads);
                                                      break;
-                        case types::Datatype::uint8 : writePyScalar<uint8_t>(ds, roiBegin, roiShape, static_cast<uint8_t>(val));
+                        case types::Datatype::uint8 : writePyScalar<uint8_t>(ds, roiBegin, roiShape,
+                                                                             static_cast<uint8_t>(val),
+                                                                             numberOfThreads);
                                                      break;
-                        case types::Datatype::uint16 : writePyScalar<uint16_t>(ds, roiBegin, roiShape, static_cast<uint16_t>(val));
+                        case types::Datatype::uint16 : writePyScalar<uint16_t>(ds, roiBegin, roiShape,
+                                                                               static_cast<uint16_t>(val),
+                                                                               numberOfThreads);
                                                      break;
-                        case types::Datatype::uint32 : writePyScalar<uint32_t>(ds, roiBegin, roiShape, static_cast<uint32_t>(val));
+                        case types::Datatype::uint32 : writePyScalar<uint32_t>(ds, roiBegin, roiShape,
+                                                                               static_cast<uint32_t>(val),
+                                                                               numberOfThreads);
                                                      break;
-                        case types::Datatype::uint64 : writePyScalar<uint64_t>(ds, roiBegin, roiShape, static_cast<uint64_t>(val));
+                        case types::Datatype::uint64 : writePyScalar<uint64_t>(ds, roiBegin, roiShape,
+                                                                               static_cast<uint64_t>(val),
+                                                                               numberOfThreads);
                                                      break;
-                        case types::Datatype::float32 : writePyScalar<float>(ds, roiBegin, roiShape, static_cast<float>(val));
+                        case types::Datatype::float32 : writePyScalar<float>(ds, roiBegin, roiShape,
+                                                                             static_cast<float>(val),
+                                                                             numberOfThreads);
                                                         break;
-                        case types::Datatype::float64 : writePyScalar<double>(ds, roiBegin, roiShape, static_cast<double>(val));
+                        case types::Datatype::float64 : writePyScalar<double>(ds, roiBegin, roiShape,
+                                                                              static_cast<double>(val),
+                                                                              numberOfThreads);
                                                         break;
                         default: throw(std::runtime_error("Invalid datatype"));
 
@@ -206,6 +228,7 @@ namespace z5 {
                   py::arg("roi_shape"),
                   py::arg("val"),
                   py::arg("dtype"),
+                  py::arg("n_threads")=1,
                   py::call_guard<py::gil_scoped_release>());
 
     }

--- a/src/python/module/z5py/base.py
+++ b/src/python/module/z5py/base.py
@@ -45,7 +45,7 @@ class Base(object):
     # TODO allow creating with data ?!
     def create_dataset(self, key, dtype, shape, chunks,
                        fill_value=0, compression='raw',
-                       **compression_options):
+                       n_threads=1, **compression_options):
         if not self._permissions.can_write():
             raise ValueError("Cannot create dataset with read-only permissions.")
         if key in self:
@@ -54,7 +54,7 @@ class Base(object):
         return Dataset.create_dataset(path, dtype, shape,
                                       chunks, self.is_zarr,
                                       compression, compression_options,
-                                      fill_value, self._internal_mode)
+                                      n_threads, fill_value, self._internal_mode)
 
     def is_group(self, key):
         path = os.path.join(self.path, key)

--- a/src/python/module/z5py/dataset.py
+++ b/src/python/module/z5py/dataset.py
@@ -299,7 +299,7 @@ class Dataset(object):
         if isinstance(item, (numbers.Number, np.number)):
             write_scalar(self._impl, roi_begin,
                          list(shape), item,
-                         str(self.dtype))
+                         str(self.dtype), self.n_threads)
             return
 
         try:

--- a/src/python/module/z5py/dataset.py
+++ b/src/python/module/z5py/dataset.py
@@ -42,7 +42,7 @@ class Dataset(object):
     zarr_default_compressor = 'blosc'
     n5_default_compressor = 'gzip'
 
-    def __init__(self, path, dset_impl, n_threads):
+    def __init__(self, path, dset_impl, n_threads=1):
         self._impl = dset_impl
         self._attrs = AttributeManager(path, self._impl.is_zarr)
         self.path = path
@@ -297,8 +297,9 @@ class Dataset(object):
 
         # broadcast scalar
         if isinstance(item, (numbers.Number, np.number)):
-            # FIXME this seems to be broken; fails with RuntimeError('WrongRequest Shape')
-            write_scalar(self._impl, roi_begin, list(shape), item)
+            write_scalar(self._impl, roi_begin,
+                         list(shape), item,
+                         str(self.dtype))
             return
 
         try:

--- a/src/python/test/test_dataset.py
+++ b/src/python/test/test_dataset.py
@@ -60,9 +60,10 @@ class DatasetTestMixin(object):
     def test_ds_dtypes(self):
         for dtype in self.dtypes:
             print("Running %s-Test for %s" % (self.data_format.title(), dtype))
-            ds = self.root_file.create_dataset(
-                'data_%s' % hash(dtype), dtype=dtype, shape=self.shape, chunks=(10, 10, 10)
-            )
+            ds = self.root_file.create_dataset('data_%s' % hash(dtype),
+                                               dtype=dtype,
+                                               shape=self.shape,
+                                               chunks=(10, 10, 10))
             in_array = 42 * np.ones(self.shape, dtype=dtype)
             ds[:] = in_array
             out_array = ds[:]
@@ -161,6 +162,18 @@ class DatasetTestMixin(object):
         ds = self.root_file.create_dataset('ones', dtype=np.uint8, shape=self.shape, chunks=(10, 10, 10))
         with self.assertRaises(TypeError):
             ds[0, 0, 0] = "hey, you're not a number"
+
+    def test_readwrite_multithreaded(self):
+        for n_threads in (1, 2, 4, 8):
+            ds = self.root_file.create_dataset('data_mthread_%i' % n_threads,
+                                               dtype='float64',
+                                               shape=self.shape,
+                                               chunks=(10, 10, 10),
+                                               n_threads=n_threads)
+            in_array = np.random.rand(*self.shape)
+            ds[:] = in_array
+            out_array = ds[:]
+            self.check_array(out_array, in_array)
 
 
 class TestZarrDataset(DatasetTestMixin, unittest.TestCase):


### PR DESCRIPTION
This PR includes two changes:
* Options for multi-threaded reading and writing of data (default is single-threaded)
* Fix Issue that prevented scalar broadcasting from python (see #50)

The number of threads can be set either when creating a dataset via
`ds = create_dataset(..., n_threads=8)` or at any time via `ds.n_threads = 8`.
Note that the number of threads will not be serialized and thus must be reset to the
desired number each time a dataset is loaded.