### PR TITLE
Regression test accuracy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
   - conda install -c conda-forge xtensor=0.15.1
   - conda install -c conda-forge xtensor-python
   - conda install -c conda-forge boost c-blosc zlib bzip2 xz
-  - conda install -c conda-forge scikit-image
+  - conda install -c conda-forge imageio
   - conda install -c anaconda cmake
   - conda install six
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ before_script:
   - conda install -c conda-forge xtensor-python
   - conda install -c conda-forge boost c-blosc zlib bzip2 xz
   - conda install -c conda-forge imageio
+  - conda install -c conda-forge zarr
+  - conda install -c conda-forge h5py
   - conda install -c anaconda cmake
   - conda install six
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_script:
   - conda install -c conda-forge imageio
   - conda install -c conda-forge zarr
   - conda install -c conda-forge h5py
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then conda install -c conda-forge futures; fi
   - conda install -c anaconda cmake
   - conda install six
 

--- a/src/bench/bench_java/n5_benchmark.py
+++ b/src/bench/bench_java/n5_benchmark.py
@@ -5,6 +5,7 @@ from shutil import rmtree
 import numpy as np
 import z5py
 from z5py.dataset import Dataset
+import z5py.util
 
 BENCH_DIR = 'bench_dir'
 

--- a/src/bench/bench_java/n5_benchmark.py
+++ b/src/bench/bench_java/n5_benchmark.py
@@ -1,16 +1,12 @@
 import os
-import zipfile
 
-from subprocess import call
 from shutil import rmtree
-from skimage import io
 
 import numpy as np
 import z5py
 from z5py.dataset import Dataset
 
 BENCH_DIR = 'bench_dir'
-IM_URL = "https://imagej.nih.gov/ij/images/t1-head-raw.zip"
 
 
 def set_up():
@@ -21,15 +17,8 @@ def set_up():
         rmtree(BENCH_DIR)
     os.mkdir(BENCH_DIR)
 
-    im_file = os.path.join(BENCH_DIR, 'im.zip')
-    call(['wget', '-O', im_file, IM_URL])
-
-    with zipfile.ZipFile(im_file) as f:
-        f.extract('JeffT1_le.tif', BENCH_DIR)
-
-    im_file = os.path.join(BENCH_DIR, 'JeffT1_le.tif')
-    im = np.array(io.imread(im_file))
-    return im[30:94, 100:164, 100:164].astype('uint8')
+    im = z5py.util.fetch_test_data()
+    return im[30:94, 100:164, 100:164]
 
 
 def benchmark_writing_speed(data):

--- a/src/python/module/z5py/util.py
+++ b/src/python/module/z5py/util.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from itertools import product
 from concurrent import futures
+from datetime import datetime
 import numpy as np
 
 from .file import File
@@ -93,3 +94,31 @@ def rechunk(in_path,
     out_attrs = ds_out.attrs
     for key, val in in_attrs.items():
         out_attrs[key] = val
+
+
+class Timer(object):
+    def __init__(self):
+        self.start_time = None
+        self.stop_time = None
+
+    @property
+    def elapsed(self):
+        try:
+            return (self.stop_time - self.start_time).total_seconds()
+        except TypeError as e:
+            if "'NoneType'" in str(e):
+                raise RuntimeError("{} either not started, or not stopped".format(self))
+
+    def start(self):
+        self.start_time = datetime.utcnow()
+
+    def stop(self):
+        self.stop_time = datetime.utcnow()
+        return self.elapsed
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()

--- a/src/python/module/z5py/util.py
+++ b/src/python/module/z5py/util.py
@@ -122,3 +122,37 @@ class Timer(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
+
+
+def fetch_test_data_stent():
+    from imageio import volread
+    data_i16 = volread('imageio:stent.npz')
+    return (data_i16 / data_i16.max() * 255).astype(np.uint8)
+
+
+def fetch_test_data():
+    try:
+        from urllib.request import urlopen
+    except ImportError:
+        from urllib2 import urlopen
+
+    try:
+        from io import BytesIO as Buffer
+    except ImportError:
+        from StringIO import StringIO as Buffer
+
+    import zipfile
+    from imageio import volread
+
+    im_url = "https://imagej.nih.gov/ij/images/t1-head-raw.zip"
+
+    with urlopen(im_url) as response:
+        if response.status != 200:
+            raise RuntimeError("Test data could not be found at {}, status code {}".format(
+                im_url, response.status
+            ))
+        zip_buffer = Buffer(response.read())
+
+    with zipfile.ZipFile(zip_buffer) as zf:
+        tif_buffer = Buffer(zf.read('JeffT1_le.tif'))
+        return np.asarray(volread(tif_buffer, format='tif'), dtype=np.uint8)

--- a/src/python/test/test_converter.py
+++ b/src/python/test/test_converter.py
@@ -5,10 +5,14 @@ import os
 from shutil import rmtree
 
 try:
-    import h5py
-    WITH_H5 = True
+    from concurrent import futures
 except ImportError:
-    WITH_H5 = False
+    futures = False
+
+try:
+    import h5py
+except ImportError:
+    h5py = False
 
 try:
     import z5py
@@ -33,7 +37,8 @@ class TestConverter(unittest.TestCase):
         if os.path.exists(self.tmp_dir):
             rmtree(self.tmp_dir)
 
-    @unittest.skipUnless(WITH_H5, 'Requires h5py')
+    @unittest.skipUnless(h5py, 'Requires h5py')
+    @unittest.skipUnless(futures, 'Needs 3rd party concurrent.futures in python 2')
     def test_h5_to_n5(self):
         from z5py.converter import convert_from_h5
         h5_file = os.path.join(self.tmp_dir, 'tmp.h5')
@@ -63,7 +68,8 @@ class TestConverter(unittest.TestCase):
             self.assertTrue(np.allclose(data, data_n5))
         print("Test h5 to n5 passed")
 
-    @unittest.skipUnless(WITH_H5, 'Requires h5py')
+    @unittest.skipUnless(h5py, 'Requires h5py')
+    @unittest.skipUnless(futures, 'Needs 3rd party concurrent.futures in python 2')
     def test_n5_to_h5(self):
         from z5py.converter import convert_to_h5
         n5_file = os.path.join(self.tmp_dir, 'tmp.n5')

--- a/src/python/test/test_regression.py
+++ b/src/python/test/test_regression.py
@@ -1,15 +1,11 @@
-import os
 import sys
 import unittest
-import zipfile
 
-from subprocess import call
 from shutil import rmtree
 from six import add_metaclass
 from abc import ABCMeta
 
 import numpy as np
-from skimage import io
 
 try:
     import z5py
@@ -22,15 +18,7 @@ except ImportError:
 class RegressionTestMixin(object):
     @classmethod
     def setUpClass(cls):
-        im_url = "https://imagej.nih.gov/ij/images/t1-head-raw.zip"
-        call(['wget', '-O', 'test.zip', im_url])
-
-        with zipfile.ZipFile('test.zip') as f:
-            f.extract('JeffT1_le.tif')
-
-        cls.data = np.array(io.imread('JeffT1_le.tif')).astype('uint8')
-        os.remove('JeffT1_le.tif')
-        os.remove('test.zip')
+        cls.data = z5py.util.fetch_test_data()
 
     def setUp(self):
         self.root_file = z5py.File('array.' + self.data_format)

--- a/src/python/test/test_regression.py
+++ b/src/python/test/test_regression.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     sys.path.append('..')
     import z5py
+import z5py.util
 
 
 @add_metaclass(ABCMeta)

--- a/src/python/test/test_regression.py
+++ b/src/python/test/test_regression.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import time
 import unittest
 import zipfile
 
@@ -51,9 +50,9 @@ class RegressionTestMixin(object):
                                                compression=compression)
             times = []
             for _ in range(self.n_reps):
-                t0 = time.time()
-                ds[:]
-                times.append(time.time() - t0)
+                with z5py.util.Timer() as t:
+                    ds[:]
+                times.append(t.elapsed)
             mint = np.min(times)
             self.assertLess(mint, expected)
 
@@ -62,10 +61,11 @@ class RegressionTestMixin(object):
             key = 'ds_%s' % compression
             times = []
             for _ in range(self.n_reps):
-                t0 = time.time()
-                self.root_file.create_dataset(key, data=self.data, chunks=self.chunks,
-                                              compression=compression)
-                times.append(time.time() - t0)
+                with z5py.util.Timer() as t:
+                    self.root_file.create_dataset(
+                        key, data=self.data, chunks=self.chunks, compression=compression
+                    )
+                times.append(t.elapsed)
                 del self.root_file[key]
             mint = np.min(times)
             self.assertLess(mint, expected)

--- a/src/python/test/test_util.py
+++ b/src/python/test/test_util.py
@@ -5,6 +5,11 @@ import os
 from shutil import rmtree
 
 try:
+    from concurrent import futures
+except ImportError:
+    futures = False
+
+try:
     import z5py
 except ImportError:
     sys.path.append('..')
@@ -24,7 +29,7 @@ class TestUtil(unittest.TestCase):
         if os.path.exists(self.tmp_dir):
             rmtree(self.tmp_dir)
 
-    @unittest.skipIf(sys.version_info.major < 3, "Needs 3rd party concurrent.futures in python 2")
+    @unittest.skipUnless(futures, "Needs 3rd party concurrent.futures in python 2")
     def test_rechunk_default(self):
         from z5py.util import rechunk
         in_path = os.path.join(self.tmp_dir, 'in.n5')
@@ -58,7 +63,7 @@ class TestUtil(unittest.TestCase):
             self.assertEqual(ds_out.chunks, new_chunks)
             self.assertTrue(np.allclose(data, data_out))
 
-    @unittest.skipIf(sys.version_info.major < 3, "Needs 3rd party concurrent.futures in python 2")
+    @unittest.skipUnless(futures, "Needs 3rd party concurrent.futures in python 2")
     def test_rechunk_custom(self):
         from z5py.util import rechunk
         in_path = os.path.join(self.tmp_dir, 'in.n5')


### PR DESCRIPTION
Firstly, use a timedelta-backed `z5py.util.Timer` to measure timings for regression tests and benchmarks, for the sake of precision.

Second change is more subjective, and it's up to you if you want it to go in: use buffers to avoid having to A) depend on `wget` and B) save intermediate files when fetching the test data set. In order to do this, I switched from using `skimage.io` to using `imageio` (which is officially the replacement for `scipy.misc.imread`), because that explicitly handles buffers, where `skimage` doesn't say it does. While doing this, I realised that `imageio` bundles its own volumetric data example, so I have a function for fetching that as an alternative, which may be less brittle. That would require re-timing the benchmarks, though.