### PR TITLE
Add __version__ and __version_info__ to __init__.py

### DIFF
--- a/src/python/module/z5py/__init__.py
+++ b/src/python/module/z5py/__init__.py
@@ -1,2 +1,6 @@
 from .file import File, N5File, ZarrFile
 from .attribute_manager import set_json_encoder, set_json_decoder
+
+__version__ = "1.1.0"
+__version_info__ = tuple(int(i) for i in  __version__.split("."))
+


### PR DESCRIPTION
For convenience.

It needs to be remembered when making new releases, though. It's easy enough to `sed` for in any release script you may have. Tools like [bumpversion](https://pypi.org/project/bumpversion/) can handle this for you, if you have the version string specified in multiple places (e.g. might be a good idea for it to be in the docs as well). 