### PR TITLE
fix file creation and add nlohmann_json support in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,12 @@ else()
     message(STATUS "xsimd not found, compiling without vector instructions")
 endif()
 
+###########################
+# nlohmann_json librarie
+###########################
+find_package(nlohmann_json REQUIRED)
+include_directories(${nlohmann_json_INCLUDE_DIRS})
+
 
 ###############################
 # Include compression libs

--- a/include/z5/file.hxx
+++ b/include/z5/file.hxx
@@ -8,15 +8,7 @@ namespace z5 {
 
     inline void createFile(const handle::File & file, const bool isZarr=true) {
         file.createDir();
-        if(isZarr) {
-            Metadata fmeta(isZarr);
-            writeMetadata(file, fmeta);
-        } else {
-            nlohmann::json n5v;
-            std::string version = "2.0.0";
-            n5v["n5"] = version;
-            writeAttributes(file, n5v);
-        }
+	Metadata fmeta(isZarr);
+	writeMetadata(file, fmeta);
     }
-
 }

--- a/include/z5/file.hxx
+++ b/include/z5/file.hxx
@@ -9,7 +9,7 @@ namespace z5 {
     inline void createFile(const handle::File & file, const bool isZarr=true) {
         file.createDir();
         if(isZarr) {
-            Metadata fmeta;
+            Metadata fmeta(isZarr);
             writeMetadata(file, fmeta);
         } else {
             nlohmann::json n5v;


### PR DESCRIPTION
This pull request:
1. added isZarr as an input argument of Metadata object in file creation. It solved the missing piece due to the commit 40856ba.

2. added nlohmann_json support in CMakeLists. nlohmann_json is included in all environment scripts but is not written into the CMakeLists.txt which leads to a missing package in the project.