### PR TITLE
Make boost::filesystem optional if we have c++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,21 +6,25 @@ project(z5)
 
 
 ##############################
-# Check and enable C++ 14
+# C++ Standard
 ##############################
 
+# check whether we have c++ 17
+
 message(STATUS "CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
-if (NOT "${CMAKE_CXX_FLAGS}" MATCHES "-std=c\\+\\+17")
+set(CPP17 "${CMAKE_CXX_FLAGS}" MATCHES "-std=c\\+\\+17" CACHE INTERNAL "")
+if (CPP17)
+    message(STATUS "Using c++ 17")
+    set(CMAKE_CXX_STANDARD 17)
+else()
     message(STATUS "Using c++ 14")
     set(CMAKE_CXX_STANDARD 14)
-else()
-    message(STATUS "Using c++ 17")
 endif()
 
 # make sure the compiler supports the requested c++ standard
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# Not sure if we should set this flag
-# set(CMAKE_CXX_EXTENSIONS OFF)
+# don't use gnu extensions
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # set default build type
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -119,7 +123,20 @@ endif()
 # find libraries - pthread
 find_package(Threads)
 
-# boost
+
+###############################
+# Boost
+###############################
+
+# If WITH_BOOST_FS is set, we always use the boost filesystem library
+# otherwise, we check if we have c++17 support. If so, we use std::filesystem,
+# otherwise we fall back to boost filesystem.
+if(CPP17)
+    SET(WITH_BOOST_FS FALSE CACHE BOOL "")
+else()
+    SET(WITH_BOOST_FS TRUE CACHE BOOL "")
+endif()
+
 if (MSVC)
     SET(BOOST_ROOT "${CMAKE_PREFIX_PATH}/Library")
     SET(BOOST_LIBRARYDIR "${CMAKE_PREFIX_PATH}/Library/lib")
@@ -128,7 +145,23 @@ else()
     SET(BOOST_LIBRARYDIR "${CMAKE_PREFIX_PATH}/lib")
 endif()
 SET(Boost_NO_SYSTEM_PATHS ON)
-find_package(Boost 1.63.0 COMPONENTS system filesystem REQUIRED)
+
+if(WITH_BOOST_FS)
+    message(STATUS "With boost filesystem")
+    find_package(Boost 1.63.0 COMPONENTS system filesystem REQUIRED)
+    add_definitions(-DWITH_BOOST_FS)
+    SET(FILESYSTEM_LIBRARIES "${Boost_FILESYSTEM_LIBRARY};${Boost_SYSTEM_LIBRARY}")
+else()
+    message(STATUS "With std filesystem")
+    find_package(Boost 1.63.0 REQUIRED)
+    # see this issue for discussions about the filesystem lib in CMake
+    # https://gitlab.kitware.com/cmake/cmake/issues/17834
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        SET(FILESYSTEM_LIBRARIES "stdc++fs")
+    else()
+        SET(FILESYSTEM_LIBRARIES "")
+    endif()
+endif()
 include_directories(${Boost_INCLUDE_DIR})
 
 
@@ -151,8 +184,9 @@ else()
     message(STATUS "xsimd not found, compiling without vector instructions")
 endif()
 
+
 ###########################
-# nlohmann_json librarie
+# nlohmann_json library
 ###########################
 find_package(nlohmann_json REQUIRED)
 include_directories(${nlohmann_json_INCLUDE_DIRS})

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ platform:
 
 image:
   - Visual Studio 2017
-  - Visual Studio 2015
 
 environment:
   matrix:
@@ -31,7 +30,6 @@ init:
 
 install:
   - set CONDA_ACTIVE_ENV=%MINICONDA%
-  - set BOOST_INCLUDE=%CONDA_ACTIVE_ENV%\\Library\\include
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
   # - conda install -vv -c conda-forge xtensor>=0.20,<0.21 xtensor-python>=0.23,<0.24 boost-cpp bzip2 blosc nlohmann_json 
@@ -39,11 +37,14 @@ install:
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build
   - cd build
-  - cmake .. -G "NMake Makefiles" -DCMAKE_PREFIX_PATH="%CONDA_ACTIVE_ENV%" -DWITH_ZLIB=ON -DWITH_BZIP2=ON -DWITH_BLOSC=ON -DWITHIN_TRAVIS=ON -DBOOST_INCLUDEDIR="%BOOST_INCLUDE%" -DBUILD_TESTS=OFF
+  - cmake .. -G "NMake Makefiles" -DCMAKE_PREFIX_PATH="%CONDA_ACTIVE_ENV%" -DWITH_ZLIB=ON -DWITH_BZIP2=ON -DWITH_BLOSC=ON -DWITHIN_TRAVIS=ON -DBUILD_TESTS=OFF
   - cmake --build . --config Release
 
 before_test:
   - set PYTHONPATH=.\python;%PYTHONPATH%
 
 test_script:
-  - python -m unittest discover -s python/test -v
+    # Appveyor tests take forever, so only running a simple one for now
+    # cf. https://github.com/constantinpape/z5/issues/125
+    # - python -m unittest discover -s python/test -v
+    - python python/test/test_group.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,8 @@ install:
   - set BOOST_INCLUDE=%CONDA_ACTIVE_ENV%\\Library\\include
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
-  - conda install -c conda-forge xtensor>=0.20,<0.21 xtensor-python>=0.23,<0.24 boost-cpp=1.69 bzip2 blosc nlohmann_json 
+  # - conda install -vv -c conda-forge xtensor>=0.20,<0.21 xtensor-python>=0.23,<0.24 boost-cpp bzip2 blosc nlohmann_json 
+  - conda install -c conda-forge boost-cpp bzip2 blosc nlohmann_json xtensor xtensor-python
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build
   - cd build

--- a/include/z5/attributes.hxx
+++ b/include/z5/attributes.hxx
@@ -1,9 +1,18 @@
 #pragma once
 
+#include <fstream>
 #include "nlohmann/json.hpp"
 #include "z5/handle/handle.hxx"
 
-namespace fs = boost::filesystem;
+#ifdef WITH_BOOST_FS
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        namespace fs = std::filesystem;
+    #else
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
 
 namespace z5 {
 
@@ -11,7 +20,11 @@ namespace attrs_detail {
 
     inline void readAttributes(fs::path & path, const std::vector<std::string> & keys, nlohmann::json & j) {
         nlohmann::json jTmp;
+        #ifdef WITH_BOOST_FS
         fs::ifstream file(path);
+        #else
+        std::ifstream file(path);
+        #endif
         file >> jTmp;
         file.close();
         for(const auto & key : keys) {
@@ -25,7 +38,11 @@ namespace attrs_detail {
     }
 
     inline void readAttributes(fs::path & path, nlohmann::json & j) {
+        #ifdef WITH_BOOST_FS
         fs::ifstream file(path);
+        #else
+        std::ifstream file(path);
+        #endif
         file >> j;
         file.close();
     }
@@ -34,14 +51,22 @@ namespace attrs_detail {
         nlohmann::json jOut;
         // if we already have attributes, read them
         if(fs::exists(path)) {
+            #ifdef WITH_BOOST_FS
             fs::ifstream file(path);
+            #else
+            std::ifstream file(path);
+            #endif
             file >> jOut;
             file.close();
         }
         for(auto jIt = j.begin(); jIt != j.end(); ++jIt) {
             jOut[jIt.key()] = jIt.value();
         }
+        #ifdef WITH_BOOST_FS
         fs::ofstream file(path);
+        #else
+        std::ofstream file(path);
+        #endif
         file << jOut;
         file.close();
     }

--- a/include/z5/dataset_factory.hxx
+++ b/include/z5/dataset_factory.hxx
@@ -4,7 +4,17 @@
 #include "z5/metadata.hxx"
 #include "z5/handle/handle.hxx"
 
-namespace fs = boost::filesystem;
+#ifdef WITH_BOOST_FS
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        namespace fs = std::filesystem;
+    #else
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
+
+
 namespace z5 {
 
     // factory function to open an existing zarr-array

--- a/include/z5/handle/file_mode.hxx
+++ b/include/z5/handle/file_mode.hxx
@@ -1,9 +1,22 @@
 #pragma once
 
 #include <array>
-#include <boost/filesystem.hpp>
 
-namespace fs = boost::filesystem;
+#ifdef WITH_BOOST_FS
+    #ifndef BOOST_FILESYSTEM_NO_DEPERECATED
+        #define BOOST_FILESYSTEM_NO_DEPERECATED
+    #endif
+    #include <boost/filesystem.hpp>
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        #include <filesystem>
+        namespace fs = std::filesystem;
+    #else
+        #include <experimental/filesystem>
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
 
 namespace z5 {
 

--- a/include/z5/handle/handle.hxx
+++ b/include/z5/handle/handle.hxx
@@ -2,16 +2,26 @@
 
 #include <string>
 
-#ifndef BOOST_FILESYSTEM_NO_DEPERECATED
-#define BOOST_FILESYSTEM_NO_DEPERECATED
+#ifdef WITH_BOOST_FS
+    #ifndef BOOST_FILESYSTEM_NO_DEPERECATED
+        #define BOOST_FILESYSTEM_NO_DEPERECATED
+    #endif
+    #include <boost/filesystem.hpp>
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        #include <filesystem>
+        namespace fs = std::filesystem;
+    #else
+        #include <experimental/filesystem>
+        namespace fs = std::experimental::filesystem;
+    #endif
 #endif
-#include <boost/filesystem.hpp>
+
 
 #include "z5/util/util.hxx"
 #include "z5/handle/file_mode.hxx"
 #include "z5/types/types.hxx"
-
-namespace fs = boost::filesystem;
 
 namespace z5 {
 namespace handle {

--- a/include/z5/io/io_base.hxx
+++ b/include/z5/io/io_base.hxx
@@ -1,13 +1,22 @@
 #pragma once
 
-#include "z5/handle/handle.hxx"
-
-#ifndef BOOST_FILESYSTEM_NO_DEPERECATED
-#define BOOST_FILESYSTEM_NO_DEPERECATED
+#ifdef WITH_BOOST_FS
+    #ifndef BOOST_FILESYSTEM_NO_DEPERECATED
+        #define BOOST_FILESYSTEM_NO_DEPERECATED
+    #endif
+    #include <boost/filesystem.hpp>
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        #include <filesystem>
+        namespace fs = std::filesystem;
+    #else
+        #include <experimental/filesystem>
+        namespace fs = std::experimental::filesystem;
+    #endif
 #endif
-#include <boost/filesystem.hpp>
 
-namespace fs = boost::filesystem;
+#include "z5/handle/handle.hxx"
 
 
 namespace z5 {

--- a/include/z5/io/io_zarr.hxx
+++ b/include/z5/io/io_zarr.hxx
@@ -2,15 +2,24 @@
 
 #include <ios>
 
-#ifndef BOOST_FILESYSTEM_NO_DEPERECATED
-#define BOOST_FILESYSTEM_NO_DEPERECATED
+#ifdef WITH_BOOST_FS
+    #ifndef BOOST_FILESYSTEM_NO_DEPERECATED
+        #define BOOST_FILESYSTEM_NO_DEPERECATED
+    #endif
+    #include <boost/filesystem.hpp>
+    #include <boost/filesystem/fstream.hpp>
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        #include <filesystem>
+        namespace fs = std::filesystem;
+    #else
+        #include <experimental/filesystem>
+        namespace fs = std::experimental::filesystem;
+    #endif
 #endif
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 #include "z5/io/io_base.hxx"
-
-namespace fs = boost::filesystem;
 
 namespace z5 {
 namespace io {
@@ -30,7 +39,11 @@ namespace io {
             if(chunk.exists()) {
 
                 // open input stream and read the filesize
+                #ifdef WITH_BOOST_FS
                 fs::ifstream file(chunk.path(), std::ios::binary);
+                #else
+                std::ifstream file(chunk.path(), std::ios::binary);
+                #endif
                 file.seekg(0, std::ios::end);
                 const std::size_t fileSize = file.tellg();
                 file.seekg(0, std::ios::beg);
@@ -56,7 +69,11 @@ namespace io {
         inline void write(const handle::Chunk & chunk, const char * data,
                           const std::size_t fileSize, const bool=false,
                           const std::size_t=0) const {
+            #ifdef WITH_BOOST_FS
             fs::ofstream file(chunk.path(), std::ios::binary);
+            #else
+            std::ofstream file(chunk.path(), std::ios::binary);
+            #endif
             file.write(data, fileSize);
             file.close();
         }

--- a/include/z5/metadata.hxx
+++ b/include/z5/metadata.hxx
@@ -4,13 +4,22 @@
 #include <vector>
 #include <iomanip>
 
-#ifndef BOOST_FILESYSTEM_NO_DEPERECATED
-#define BOOST_FILESYSTEM_NO_DEPERECATED
+#ifdef WITH_BOOST_FS
+    #ifndef BOOST_FILESYSTEM_NO_DEPERECATED
+        #define BOOST_FILESYSTEM_NO_DEPERECATED
+    #endif
+    #include <boost/filesystem.hpp>
+    #include <boost/filesystem/fstream.hpp>
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        #include <filesystem>
+        namespace fs = std::filesystem;
+    #else
+        #include <experimental/filesystem>
+        namespace fs = std::experimental::filesystem;
+    #endif
 #endif
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
-
-namespace fs = boost::filesystem;
 
 #include "z5/attributes.hxx"
 #include "z5/handle/handle.hxx"
@@ -281,7 +290,11 @@ namespace z5 {
             } catch(std::runtime_error) {}  // read attributes throws RE if there are no attributes, we can just ignore this
             j["n5"] = metadata.n5Format;
         }
+        #ifdef WITH_BOOST_FS
         fs::ofstream file(filePath);
+        #else
+        std::ofstream file(filePath);
+        #endif
         file << std::setw(4) << j << std::endl;
         file.close();
     }
@@ -298,7 +311,11 @@ namespace z5 {
             // we don't need to write metadata for n5 groups
             return;
         }
+        #ifdef WITH_BOOST_FS
         fs::ofstream file(filePath);
+        #else
+        std::ofstream file(filePath);
+        #endif
         file << std::setw(4) << j << std::endl;
         file.close();
     }
@@ -309,7 +326,11 @@ namespace z5 {
         nlohmann::json j;
         metadata.toJson(j);
         filePath /= metadata.isZarr ? ".zarray" : "attributes.json";
+        #ifdef WITH_BOOST_FS
         fs::ofstream file(filePath);
+        #else
+        std::ofstream file(filePath);
+        #endif
         file << std::setw(4) << j << std::endl;
         file.close();
     }
@@ -336,7 +357,11 @@ namespace z5 {
         nlohmann::json j;
         fs::path filePath;
         auto isZarr = getMetadataPath(handle, filePath);
+        #ifdef WITH_BOOST_FS
         fs::ifstream file(filePath);
+        #else
+        std::ifstream file(filePath);
+        #endif
         file >> j;
         metadata.fromJson(j, isZarr);
         file.close();
@@ -346,7 +371,11 @@ namespace z5 {
     inline types::Datatype readDatatype(const handle::Dataset & handle) {
         fs::path filePath;
         bool isZarr = getMetadataPath(handle, filePath);
+        #ifdef WITH_BOOST_FS
         fs::ifstream file(filePath);
+        #else
+        std::ifstream file(filePath);
+        #endif
         nlohmann::json j;
         file >> j;
         file.close();

--- a/include/z5/util/functions.hxx
+++ b/include/z5/util/functions.hxx
@@ -1,13 +1,22 @@
 #pragma once
 
-#ifndef BOOST_FILESYSTEM_NO_DEPERECATED
-#define BOOST_FILESYSTEM_NO_DEPERECATED
+#ifdef WITH_BOOST_FS
+    #ifndef BOOST_FILESYSTEM_NO_DEPERECATED
+        #define BOOST_FILESYSTEM_NO_DEPERECATED
+    #endif
+    #include <boost/filesystem.hpp>
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        #include <filesystem>
+        namespace fs = std::filesystem;
+    #else
+        #include <experimental/filesystem>
+        namespace fs = std::experimental::filesystem;
+    #endif
 #endif
-#include <boost/filesystem.hpp>
 
 #include "z5/util/for_each.hxx"
-
-namespace fs = boost::filesystem;
 
 
 namespace z5 {

--- a/src/python/lib/CMakeLists.txt
+++ b/src/python/lib/CMakeLists.txt
@@ -7,7 +7,6 @@ addPythonModule(
         util.cxx
     LIBRRARIES
         ${COMPRESSION_LIBRARIES} 
-        ${Boost_FILESYSTEM_LIBRARY}    
-        ${Boost_SYSTEM_LIBRARY}    
+        ${FILESYSTEM_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT}
 )

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,10 +1,9 @@
 # define test libraries
 SET(TEST_LIBS
-    ${Boost_FILESYSTEM_LIBRARY}    
-    ${Boost_SYSTEM_LIBRARY}    
     gtest
     gtest_main
     ${CMAKE_THREAD_LIBS_INIT}
+    ${FILESYSTEM_LIBRARIES}
 )
 
 # add metadata test

--- a/src/test/io/test_helper.hxx
+++ b/src/test/io/test_helper.hxx
@@ -1,8 +1,24 @@
 #pragma once
 
 #include <random>
-#define BOOST_FILESYSTEM_NO_DEPERECATED
-#include <boost/filesystem.hpp>
+#include <fstream>
+
+#ifdef WITH_BOOST_FS
+    #ifndef BOOST_FILESYSTEM_NO_DEPERECATED
+        #define BOOST_FILESYSTEM_NO_DEPERECATED
+    #endif
+    #include <boost/filesystem.hpp>
+    #include <boost/filesystem/fstream.hpp>
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        #include <filesystem>
+        namespace fs = std::filesystem;
+    #else
+        #include <experimental/filesystem>
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
 
 #include "gtest/gtest.h"
 #include "z5/util/util.hxx"
@@ -10,7 +26,6 @@
 
 #define SIZE 100*100*100
 
-namespace fs = boost::filesystem;
 
 namespace z5 {
 namespace io {
@@ -40,13 +55,21 @@ namespace io {
             fs::create_directory(arr5);
 
             // write to file
+            #ifdef WITH_BOOST_FS
             fs::fstream file("array.zr/0.0.0", std::ios::out | std::ios::binary);
+            #else
+            std::fstream file("array.zr/0.0.0", std::ios::out | std::ios::binary);
+            #endif
             file.write((char*) data_, SIZE*sizeof(int));
 
             // write to file
             fs::path n5_chunk("array.n5/0/0");
             fs::create_directories(n5_chunk);
+            #ifdef WITH_BOOST_FS
             fs::fstream file1("array.n5/0/0/0", std::ios::out | std::ios::binary);
+            #else
+            std::fstream file1("array.n5/0/0/0", std::ios::out | std::ios::binary);
+            #endif
             // need to write header first
             uint16_t mode = 0; // TODO support the varlength mode as well
             util::reverseEndiannessInplace(mode);

--- a/src/test/io/test_io_n5.cxx
+++ b/src/test/io/test_io_n5.cxx
@@ -2,8 +2,15 @@
 #include "z5/io/io_n5.hxx"
 #include "z5/dataset_factory.hxx"
 
-
-namespace fs = boost::filesystem;
+#ifdef WITH_BOOST_FS
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        namespace fs = std::filesystem;
+    #else
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
 
 namespace z5 {
 namespace io {

--- a/src/test/io/test_io_zarr.cxx
+++ b/src/test/io/test_io_zarr.cxx
@@ -1,7 +1,15 @@
 #include "test_helper.hxx"
 #include "z5/io/io_zarr.hxx"
 
-namespace fs = boost::filesystem;
+#ifdef WITH_BOOST_FS
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        namespace fs = std::filesystem;
+    #else
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
 
 namespace z5 {
 namespace io {

--- a/src/test/multiarray/test_broadcast.cxx
+++ b/src/test/multiarray/test_broadcast.cxx
@@ -6,7 +6,15 @@
 #include "z5/dataset_factory.hxx"
 #include "z5/multiarray/broadcast.hxx"
 
-namespace fs = boost::filesystem;
+#ifdef WITH_BOOST_FS
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        namespace fs = std::filesystem;
+    #else
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
 
 namespace z5 {
 namespace multiarray {

--- a/src/test/multiarray/test_marray.cxx
+++ b/src/test/multiarray/test_marray.cxx
@@ -5,7 +5,15 @@
 #include "z5/dataset_factory.hxx"
 #include "z5/multiarray/marray_access.hxx"
 
-namespace fs = boost::filesystem;
+#ifdef WITH_BOOST_FS
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        namespace fs = std::filesystem;
+    #else
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
 
 namespace z5 {
 namespace multiarray {

--- a/src/test/multiarray/test_xtensor.cxx
+++ b/src/test/multiarray/test_xtensor.cxx
@@ -6,7 +6,15 @@
 #include "z5/dataset_factory.hxx"
 #include "z5/multiarray/xtensor_access.hxx"
 
-namespace fs = boost::filesystem;
+#ifdef WITH_BOOST_FS
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        namespace fs = std::filesystem;
+    #else
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
 
 namespace z5 {
 namespace multiarray {

--- a/src/test/multiarray/test_xtnd.cxx
+++ b/src/test/multiarray/test_xtnd.cxx
@@ -6,7 +6,15 @@
 #include "z5/dataset_factory.hxx"
 #include "z5/multiarray/xtensor_access.hxx"
 
-namespace fs = boost::filesystem;
+#ifdef WITH_BOOST_FS
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        namespace fs = std::filesystem;
+    #else
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
 
 #define MIN_DIM 1
 #define MAX_DIM 6

--- a/src/test/multiarray/test_xtutil.cxx
+++ b/src/test/multiarray/test_xtutil.cxx
@@ -39,7 +39,7 @@ namespace multiarray {
 
             // make the big array and view
             xt::xarray<int> array = xt::zeros<int>(shape);
-            xt::slice_vector slice;
+            xt::xstrided_slice_vector slice;
             sliceFromRoi(slice, viewOffset, viewShape);
             auto view = xt::strided_view(array, slice);
 
@@ -84,7 +84,7 @@ namespace multiarray {
 
             // make the big array and view
             xt::xarray<int> array = xt::zeros<int>(shape);
-            xt::slice_vector slice;
+            xt::xstrided_slice_vector slice;
             sliceFromRoi(slice, viewOffset, viewShape);
             auto view = xt::strided_view(array, slice);
             std::iota(view.begin(), view.end(), 0);

--- a/src/test/test_attributes.cxx
+++ b/src/test/test_attributes.cxx
@@ -4,7 +4,15 @@
 #include "z5/attributes.hxx"
 #include "z5/dataset_factory.hxx"
 
-namespace fs = boost::filesystem;
+#ifdef WITH_BOOST_FS
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        namespace fs = std::filesystem;
+    #else
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
 
 namespace z5 {
 

--- a/src/test/test_dataset.cxx
+++ b/src/test/test_dataset.cxx
@@ -5,7 +5,15 @@
 #include "z5/metadata.hxx"
 #include "z5/dataset.hxx"
 
-namespace fs = boost::filesystem;
+#ifdef WITH_BOOST_FS
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        namespace fs = std::filesystem;
+    #else
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
 
 namespace z5 {
 

--- a/src/test/test_factories.cxx
+++ b/src/test/test_factories.cxx
@@ -5,7 +5,15 @@
 #include "z5/metadata.hxx"
 #include "z5/dataset_factory.hxx"
 
-namespace fs = boost::filesystem;
+#ifdef WITH_BOOST_FS
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        namespace fs = std::filesystem;
+    #else
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
 
 #define SIZE 10*10*10
 

--- a/src/test/test_metadata.cxx
+++ b/src/test/test_metadata.cxx
@@ -3,7 +3,15 @@
 
 #include "z5/metadata.hxx"
 
-namespace fs = boost::filesystem;
+#ifdef WITH_BOOST_FS
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        namespace fs = std::filesystem;
+    #else
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
 
 namespace z5 {
 
@@ -26,7 +34,11 @@ namespace z5 {
             fs::path mdata("array.zr");
             fs::create_directory(mdata);
             mdata /= ".zarray";
+            #ifdef WITH_BOOST_FS
             fs::ofstream file(mdata);
+            #else
+            std::ofstream file(mdata);
+            #endif
             file << jZarr;
             file.close();
 
@@ -34,7 +46,11 @@ namespace z5 {
             fs::path mdataN5("array.n5");
             fs::create_directory(mdataN5);
             mdataN5 /= "attributes.json";
+            #ifdef WITH_BOOST_FS
             fs::ofstream fileN5(mdataN5);
+            #else
+            std::ofstream fileN5(mdataN5);
+            #endif
             fileN5 << jN5;
             fileN5.close();
         }

--- a/src/test/test_n5/test_n5.cxx
+++ b/src/test/test_n5/test_n5.cxx
@@ -2,7 +2,16 @@
 
 #include "z5/dataset_factory.hxx"
 
-namespace fs = boost::filesystem;
+#ifdef WITH_BOOST_FS
+    namespace fs = boost::filesystem;
+#else
+    #if __GCC__ > 7
+        namespace fs = std::filesystem;
+    #else
+        namespace fs = std::experimental::filesystem;
+    #endif
+#endif
+
 namespace z5 {
 
     // fixture for the zarr array test


### PR DESCRIPTION
This turned out to be a bit more complicated due to std::experimental::filesystem in gcc7.