### PR TITLE
added #include <set>

### DIFF
--- a/include/z5/handle.hxx
+++ b/include/z5/handle.hxx
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <set>
 #include "z5/types/types.hxx"
 #include "z5/util/file_mode.hxx"
 #include "z5/util/util.hxx"


### PR DESCRIPTION
Hello @constantinpape ,
thank you for this awesome library.
The **z5 library** is currently used during reinforcement learning for a neural network chess variant engine _CrazyAra_ to export data in the [**Zarr**](https://github.com/zarr-developers/zarr-python) data format.
* https://github.com/QueensGambit/CrazyAra/blob/master/engine/src/rl/traindataexporter.h

I needed to add `#include <set>` from the C++ standard library to avoid compilation errors on my system.
* https://github.com/constantinpape/z5/blob/master/include/z5/handle.hxx#L166

Moreover, it could be useful to add a note in the readme install instructions that the [boost library](https://www.boost.org/) is required to use the **z5 library**.
Currently, the boost library is installed form sourceforge.net via our Dockerfile:
* https://github.com/QueensGambit/CrazyAra/blob/master/engine/src/rl/Dockerfile#L48

I would like to mention your library in my master thesis.
Is there a recommend way for doing so?
Otherwise I would rely on the default way of citing GitHub repositories:
```
@misc{pape_z5_2019,
	title = {constantinpape/z5},
	copyright = {MIT},
	url = {https://github.com/constantinpape/z5},
	abstract = {Lighweight C++ and Python interface for datasets in zarr and N5 format},
	urldate = {2019-12-19},
	author = {Pape, Constantin},
	month = dec,
	year = {2019},
	note = {original-date: 2017-08-29T00:31:10Z},
	keywords = {cloud, h5py, n5, storage, zarr}
}
```