### PR TITLE
Update compression

### DIFF
--- a/include/z5/types/types.hxx
+++ b/include/z5/types/types.hxx
@@ -234,6 +234,9 @@ namespace types {
             #ifdef WITH_BZIP2
             case bzip2: options["level"] = jOpts["level"].get<int>(); break;
             #endif
+            #ifdef WITH_LZ4
+            case lz4: options["level"] = jOpts["acceleration"].get<int>(); break;
+            #endif
             // raw compression has no parameters
             default: break;
         }
@@ -267,6 +270,9 @@ namespace types {
             #endif
             #ifdef WITH_BZIP2
             case bzip2: jOpts["level"] = boost::get<int>(options.at("level")); break;
+            #endif
+            #ifdef WITH_LZ4
+            case lz4: jOpts["acceleration"] = boost::get<int>(options.at("level")); break;
             #endif
             // raw compression has no parameters
             default: break;

--- a/include/z5/types/types.hxx
+++ b/include/z5/types/types.hxx
@@ -349,6 +349,14 @@ namespace types {
             case bzip2: if(options.find("level") == options.end()){options["level"] = 5;}
                         break;
             #endif
+            #ifdef WITH_LZ4
+            case lz4: if(options.find("level") == options.end()){options["level"] = 6;}
+                      break;
+            #endif
+            #ifdef WITH_XZ
+            case xz: if(options.find("level") == options.end()){options["level"] = 6;}
+                     break;
+            #endif
             // raw compression has no parameters
             default: break;
         }

--- a/include/z5/types/types.hxx
+++ b/include/z5/types/types.hxx
@@ -174,7 +174,10 @@ namespace types {
                 {"xz", xz},
                 #endif
                 #ifdef WITH_LZ4
-                {"lz4", lz4}
+                {"lz4", lz4},
+                #endif
+                #ifdef WITH_BLOSC
+                {"blosc", blosc}
                 #endif
             }});
             return cMap;
@@ -193,7 +196,10 @@ namespace types {
                 {xz, "xz"},
                 #endif
                 #ifdef WITH_LZ4
-                {lz4, "lz4"}
+                {lz4, "lz4"},
+                #endif
+                #ifdef WITH_LZ4
+                {blosc, "blosc"}
                 #endif
             }});
             return cMap;
@@ -299,6 +305,12 @@ namespace types {
             #ifdef WITH_LZ4
             case lz4: options["level"] = jOpts["blockSize"].get<int>(); break;
             #endif
+            #ifdef WITH_BLOSC
+            case blosc: options["codec"] = jOpts["cname"].get<std::string>();
+                        options["level"] = jOpts["clevel"].get<int>();
+                        options["shuffle"] = jOpts["shuffle"].get<int>();
+                        break;
+            #endif
             // raw compression has no parameters
             default: break;
         }
@@ -328,6 +340,12 @@ namespace types {
             #endif
             #ifdef WITH_LZ4
             case lz4: jOpts["blockSize"] = boost::get<int>(options.at("level")); break;
+            #endif
+            #ifdef WITH_BLOSC
+            case blosc: jOpts["cname"] = boost::get<std::string>(options.at("codec"));
+                        jOpts["clevel"] = boost::get<int>(options.at("level"));
+                        jOpts["shuffle"] = boost::get<int>(options.at("shuffle"));
+                        break;
             #endif
             // raw compression has no parameters
             default: break;

--- a/src/python/module/z5py/dataset.py
+++ b/src/python/module/z5py/dataset.py
@@ -8,7 +8,7 @@ from .attribute_manager import AttributeManager
 from .shape_utils import normalize_slices, rectify_shape, get_default_chunks
 
 AVAILABLE_COMPRESSORS = _z5py.get_available_codecs()
-COMPRESSORS_ZARR = ('raw', 'blosc', 'zlib', 'bzip2', 'gzip')
+COMPRESSORS_ZARR = ('raw', 'blosc', 'zlib', 'bzip2', 'gzip', 'lz4')
 COMPRESSORS_N5 = ('raw', 'gzip', 'bzip2', 'xz', 'lz4')
 
 
@@ -59,6 +59,8 @@ class Dataset:
             default_opts = {'id': 'gzip', 'level': 5}
         elif compression == 'bzip2':
             default_opts = {'level': 5}
+        elif compression == 'lz4':
+            default_opts = {'level': 6}
         elif compression == 'raw':
             default_opts = {}
         else:

--- a/src/python/module/z5py/dataset.py
+++ b/src/python/module/z5py/dataset.py
@@ -9,7 +9,7 @@ from .shape_utils import normalize_slices, rectify_shape, get_default_chunks
 
 AVAILABLE_COMPRESSORS = _z5py.get_available_codecs()
 COMPRESSORS_ZARR = ('raw', 'blosc', 'zlib', 'bzip2', 'gzip', 'lz4')
-COMPRESSORS_N5 = ('raw', 'gzip', 'bzip2', 'xz', 'lz4')
+COMPRESSORS_N5 = ('raw', 'blosc', 'gzip', 'bzip2', 'xz', 'lz4')
 
 
 class Dataset:
@@ -91,6 +91,8 @@ class Dataset:
             default_opts = {'level': 6}
         elif compression == 'lz4':
             default_opts = {'level': 6}
+        elif compression == 'blosc':
+            default_opts = {'codec': 'lz4', 'clevel': 5, 'shuffle': 1}
         else:
             raise RuntimeError("Compression %s is not supported in n5 format" % compression)
 

--- a/src/python/module/z5py/dataset.py
+++ b/src/python/module/z5py/dataset.py
@@ -8,7 +8,9 @@ from .attribute_manager import AttributeManager
 from .shape_utils import normalize_slices, rectify_shape, get_default_chunks
 
 AVAILABLE_COMPRESSORS = _z5py.get_available_codecs()
-COMPRESSORS_ZARR = ('raw', 'blosc', 'zlib', 'bzip2', 'gzip', 'lz4')
+# TODO lz4 compression is currently not compatible with zarr
+# COMPRESSORS_ZARR = ('raw', 'blosc', 'zlib', 'bzip2', 'gzip', 'lz4')
+COMPRESSORS_ZARR = ('raw', 'blosc', 'zlib', 'bzip2', 'gzip')
 COMPRESSORS_N5 = ('raw', 'blosc', 'gzip', 'bzip2', 'xz', 'lz4')
 
 

--- a/src/python/test/test_compression.py
+++ b/src/python/test/test_compression.py
@@ -8,7 +8,8 @@ import z5py
 
 class CompressionTestMixin(ABC):
     def setUp(self):
-        self.shape = (100, 100, 100)
+        self.shape = (500, 500)
+        self.chunks = (100, 100)
         self.root_file = z5py.File('array.' + self.data_format, use_zarr_format=self.data_format == 'zarr')
 
         self.dtypes = [
@@ -48,7 +49,7 @@ class CompressionTestMixin(ABC):
                 try:
                     ds = f.create_dataset(ds_name,
                                           data=in_array,
-                                          chunks=(10, 10, 10),
+                                          chunks=self.chunks,
                                           compression=compression)
                     out_array = ds[:]
                     self.check_array(out_array, in_array,
@@ -80,7 +81,7 @@ class CompressionTestMixin(ABC):
             np.random.shuffle(in_array)
             ds = f.create_dataset(ds_name,
                                   data=in_array,
-                                  chunks=(10, 10, 10),
+                                  chunks=self.chunks,
                                   compression=compression)
             out_array = ds[:]
             self.check_array(out_array, in_array,

--- a/src/python/test/test_zarr.py
+++ b/src/python/test/test_zarr.py
@@ -60,6 +60,8 @@ class TestZarr(unittest.TestCase):
                             'zlib': numcodecs.Zlib(),
                             'raw': None,
                             'bzip2': numcodecs.BZ2()}
+        # TODO lz4 compression is currently not compatible with zarr
+        # 'lz4': numcodecs.LZ4()}
 
         # conda-forge version of numcodecs is not up-to-data
         # for python 3.5 and GZip is missing

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -29,8 +29,8 @@ target_link_libraries(test_attributes ${TEST_LIBS} ${COMPRESSION_LIBRARIES})
  
 add_subdirectory(compression)
 add_subdirectory(multiarray)
-# add_subdirectory(test_n5)
 add_subdirectory(util)
+# add_subdirectory(test_n5)
 
 if(WITH_S3)
     add_subdirectory(s3)

--- a/src/test/run_all_tests.sh
+++ b/src/test/run_all_tests.sh
@@ -11,35 +11,35 @@ echo "Running Attributes Test"
 ./test_attributes
 
 echo "Running Compression Tests"
-echo "Raw Compression"
 ./compression/test_raw
-echo "Zlib Compression"
-./compression/test_zlib
-echo "Bzip2 Compression"
-./compression/test_bzip2
-echo "Blosc Compression"
-./compression/test_blosc
+if [ -f ./compression/test_blosc ]; then
+    ./compression/test_blosc
+fi
+if [ -f ./compression/test_bzip2 ]; then
+    ./compression/test_bzip2
+fi
+if [ -f ./compression/test_lz4 ]; then
+    ./compression/test_lz4
+fi
+if [ -f ./compression/test_xz ]; then
+    ./compression/test_xz
+fi
+if [ -f ./compression/test_zlib ]; then
+    ./compression/test_zlib
+fi
 
-echo "Running IO Tests"
-echo "Io N5"
-./io/test_io_n5
-echo "Io Zarr"
-./io/test_io_zarr
-
-echo "Running Multiarray Tests"
 if [ -f ./multiarray/test_marray ]; then
-    echo "Marray Tests"
+    echo "Running Marray Tests"
     ./multiarray/test_marray
 fi
 
-echo "XT Tests"
-cd multiarray
-./test_broadcast
-./test_xtensor
-./test_xtnd
-cd ..
+echo "Running Xtensor Tests"
+./multiarray/test_broadcast
+./multiarray/test_xtensor
+./multiarray/test_xtnd
 
-echo "Running N5 Tests"
-cd test_n5
-./run_test.bash
-cd ..
+# don't run n5 tests in test runner, we can't run them in travis
+# echo "Running N5 Tests"
+# cd test_n5
+# ./run_test.bash
+# cd ..

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -35,6 +35,7 @@ if [ $TRAVIS_OS_NAME = 'osx' ]; then
         -DPYTHON_EXECUTABLE="$PY_BIN" \
         -DCMAKE_CXX_FLAGS="-std=c++17" \
         -DWITH_BOOST_FS=ON \
+        -DBUILD_TESTS=ON \
         -DBUILD_Z5PY=ON
 else
     cmake . \
@@ -48,6 +49,7 @@ else
         -DCMAKE_PREFIX_PATH="$ENV_ROOT" \
         -DPYTHON_EXECUTABLE="$PY_BIN" \
         -DCMAKE_CXX_FLAGS="-std=c++17" \
+        -DBUILD_TESTS=ON \
         -DBUILD_Z5PY=ON
 fi
 


### PR DESCRIPTION
- Add missing default compression parameters for `xz` and `lz4`, see #156 
- Support `lz4` compression in zarr
- Support `blosc` compression in n5, see #156 

TODO need to check that the attributes written with blosc compression are compatible with https://github.com/saalfeldlab/n5-blosc.