### PR TITLE
Fix error when pathlib.Path is supplied to File

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,11 +16,6 @@ environment:
     - MINICONDA: C:\xtensor-conda
       PYVER: 3.7
 
-clone_script:
-  - cmd: git clone -q --branch=%APPVEYOR_REPO_BRANCH% https://github.com/%APPVEYOR_REPO_NAME%.git %APPVEYOR_BUILD_FOLDER%
-  - cmd: cd %APPVEYOR_BUILD_FOLDER%
-  - cmd: git checkout -qf %APPVEYOR_REPO_COMMIT%
-
 init:
   - "ECHO %MINICONDA%"
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -43,3 +43,7 @@ requirements:
 test:
   imports:
     - z5py
+  source_files:
+    - src/python/test/*.py
+  commands:
+    - python -m unittest discover -s src/python/test -v

--- a/src/python/module/z5py/file.py
+++ b/src/python/module/z5py/file.py
@@ -1,6 +1,7 @@
 import json
 import os
 import errno
+import pathlib
 
 from . import _z5py
 from .group import Group
@@ -48,6 +49,8 @@ class File(Group):
 
     def __init__(self, path, mode='a', use_zarr_format=None):
 
+        if isinstance(path, os.PathLike):
+            path = os.fspath(path)
         # infer the file format from the path
         is_zarr = self.infer_format(path)
         # check if the format that was infered is consistent with `use_zarr_format`

--- a/src/python/test/test_file.py
+++ b/src/python/test/test_file.py
@@ -2,6 +2,7 @@ import unittest
 import os
 from shutil import rmtree
 from abc import ABC
+import pathlib
 
 import z5py
 
@@ -82,6 +83,16 @@ class TestN5File(FileTestMixin, unittest.TestCase):
     def test_direct_constructor(self):
         self.assertFalse(os.path.exists(self.path))
         f = z5py.N5File(self.path)
+        self.assertFalse(f.is_zarr)
+
+
+class TestPathlibPath(FileTestMixin, unittest.TestCase):
+    data_format = 'n5'
+
+    def test_direct_constructor(self):
+        self.assertFalse(os.path.exists(self.path))
+        path = pathlib.Path(self.path)
+        f = z5py.N5File(path)
         self.assertFalse(f.is_zarr)
 
 


### PR DESCRIPTION
Added a check if path that is supplied to File is of type `pathlib.Path`.

Also added a test for it and made the conda recipe run the tests.

fixes #160 
