### PR TITLE
Implement assarray in the z5py dataset class for better numpy interactions

### DIFF
--- a/src/python/module/z5py/dataset.py
+++ b/src/python/module/z5py/dataset.py
@@ -51,6 +51,9 @@ class Dataset:
         self._parent = parent
         self._name = name
 
+    def __array__(self):
+        return self[...]
+
     @staticmethod
     def _to_zarr_compression_options(compression, compression_options):
         if compression == 'blosc':

--- a/src/python/test/test_asarray.py
+++ b/src/python/test/test_asarray.py
@@ -1,0 +1,37 @@
+import unittest
+import pickle
+import sys
+from shutil import rmtree
+
+import numpy as np
+
+try:
+    import z5py
+except ImportError:
+    sys.path.append('..')
+    import z5py
+
+
+class TestAsarray(unittest.TestCase):
+
+    def setUp(self):
+        sample_data = np.array([ [3, 4], [7, 8]])
+        self.test_fn = 'test.n5'
+        self.test_ds = 'test'
+        with z5py.File(self.test_fn, 'w') as zfh:
+            zfh.create_dataset(self.test_ds, data=sample_data)
+        self.ff = z5py.File(self.test_fn, 'r')
+        
+
+    def tearDown(self):
+        try:
+            rmtree(self.test_fn)
+        except OSError:
+            pass
+
+    def test_asarray(self):
+        uniques = np.unique(self.ff[self.test_ds])
+        self.assertEqual(len(uniques), 4)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This addresses #179 and makes z5py more feature-for-feature compatible with h5py (using this interface may not be suitable for larger datasets, but that is the same as h5py).