### PR TITLE
Work around MSVC build issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,14 @@ jobs:
         with:
             submodules: 'recursive'
 
+      # this will set the system compiler;
+      # I don't know how to set the conda compilers for windows
+      # This must be done *before* setting up miniconda, see:
+      # https://github.com/ilammy/msvc-dev-cmd/issues/34
+      - name: Set windows env
+        if: matrix.os == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Setup miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -31,12 +39,6 @@ jobs:
           auto-activate-base: false
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-
-      # this will set the system compiler;
-      # I don't know how to set the conda compilers for windows
-      - name: Set windows env
-        if: matrix.os == 'windows-latest'
-        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build linux
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
For some reason `msvc-dev-cmd` does not really like the environment after `setup-miniconda` does its job. As a workaround, configure MSVC environment first, then install miniconda. This lets them coexist for now.

Once the issue with `msvc-dev-cmd` is resolved (https://github.com/ilammy/msvc-dev-cmd/issues/34), this step can be moved back to its original location.

Supersedes: #181