### PR TITLE
Fix typos found by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ it is recommended to use these implementations, which are more thoroughly tested
 
 ## Current Limitations / TODOs
 
-- No thread / process synchonization -> writing to the same chunk in parallel will lead to undefined behavior.
+- No thread / process synchronization -> writing to the same chunk in parallel will lead to undefined behavior.
 - Supports only little endianness and C-order for the zarr format.
 
 

--- a/include/z5/compression/xz_compressor.hxx
+++ b/include/z5/compression/xz_compressor.hxx
@@ -98,7 +98,7 @@ namespace compression {
             auto action = LZMA_RUN;
             std::size_t currentPosition = 0;
             do {
-                // set the stream outout to the output dat at the current position
+                // set the stream output to the output dat at the current position
                 // and set the available size to the remaining bytes in the output data
                 lzs.next_out = reinterpret_cast<uint8_t*>(dataOut + currentPosition);
                 lzs.avail_out = (sizeOut - currentPosition) * sizeof(T);

--- a/include/z5/compression/zlib_compressor.hxx
+++ b/include/z5/compression/zlib_compressor.hxx
@@ -117,7 +117,7 @@ namespace compression {
             int ret;
             std::size_t currentPosition = 0;
             do {
-                // set the stream outout to the output dat at the current position
+                // set the stream output to the output dat at the current position
                 // and set the available size to the remaining bytes in the output data
                 // reinterpret_cast because (Bytef*) throws warning
                 zs.next_out = reinterpret_cast<Bytef*>(dataOut + currentPosition);

--- a/include/z5/filesystem/dataset.hxx
+++ b/include/z5/filesystem/dataset.hxx
@@ -76,7 +76,7 @@ namespace filesystem {
             // make sure that we have a valid chunk
             checkChunk(chunk);
 
-            // throw runtime errror if trying to read non-existing chunk
+            // throw runtime error if trying to read non-existing chunk
             if(!chunk.exists()) {
                 throw std::runtime_error("Trying to read a chunk that does not exist");
             }
@@ -305,7 +305,7 @@ namespace filesystem {
             file.read((char *) &ndim, 2);
             util::reverseEndiannessInplace(ndim);
 
-            // read tempory shape with uint32 entries
+            // read temporary shape with uint32 entries
             std::vector<uint32_t> shapeTmp(ndim);
             for(int d = 0; d < ndim; ++d) {
                 file.read((char *) &shapeTmp[d], 4);

--- a/include/z5/filesystem/handle.hxx
+++ b/include/z5/filesystem/handle.hxx
@@ -296,7 +296,7 @@ namespace handle {
 
 
     //
-    // additional handle factory functions for compatability with C
+    // additional handle factory functions for compatibility with C
     //
 
     // TODO need to expose FileMode as well

--- a/include/z5/handle.hxx
+++ b/include/z5/handle.hxx
@@ -16,7 +16,7 @@ namespace handle {
      * - File: the root group (= top level directory) for a zarr/n5 container
      * - Group: a directory that is not a dataset, i.e. does not contain nd-data
      * - Dataset: a directory that contains nd-data stored in chunks (individual files)
-     * - Chunk: an individual chunk fule in an dataset
+     * - Chunk: an individual chunk file in a dataset
      *
      * The common functionality for all handles is defined in the class Handle.
      * It includes checking whether the current object is part of a zarr or an n5 container,
@@ -65,7 +65,7 @@ namespace handle {
 
 
     //
-    // We use CRTP desing for Group, File, Dataset and Chunk handles
+    // We use CRTP design for Group, File, Dataset and Chunk handles
     // in order to infer the handle type from the base class
     // via 'derived_cast'. or call the derived class implementations (for Chunk)
     //
@@ -152,7 +152,7 @@ namespace handle {
 			std::string name;
 
             // if we have the zarr-format, chunk indices
-            // are seperated by a '.'
+            // are separated by a '.'
             if(isZarr) {
                 std::string delimiter = ".";
                 util::join(indices.begin(), indices.end(), name, delimiter);

--- a/include/z5/multiarray/xtensor_util.hxx
+++ b/include/z5/multiarray/xtensor_util.hxx
@@ -30,7 +30,7 @@ namespace multiarray {
             flatOffset += (outStrides[d] * offsetInRequest[d]);
         }
 
-        // TODO this depends on the laout type.....
+        // TODO this depends on the layout type.....
         // next, calculate the new strides
         requestStrides.resize(requestShape.size());
         for(int d = 0; d < requestShape.size(); ++d) {

--- a/include/z5/s3/dataset.hxx
+++ b/include/z5/s3/dataset.hxx
@@ -55,7 +55,7 @@ namespace s3 {
             // make sure that we have a valid chunk
             // checkChunk(chunk);
 
-            // throw runtime errror if trying to read non-existing chunk
+            // throw runtime error if trying to read non-existing chunk
             if(!chunk.exists()) {
                 throw std::runtime_error("Trying to read a chunk that does not exist");
             }

--- a/include/z5/s3/handle.hxx
+++ b/include/z5/s3/handle.hxx
@@ -300,7 +300,7 @@ namespace handle {
 
 
     //
-    // additional handle factory functions for compatability with C
+    // additional handle factory functions for compatibility with C
     //
 
     // TODO

--- a/include/z5/types/types.hxx
+++ b/include/z5/types/types.hxx
@@ -418,7 +418,7 @@ namespace types {
     }
 
 } // namespace::types
-    // overload ostream operator for ShapeType (a.k.a) vector for convinience
+    // overload ostream operator for ShapeType (a.k.a) vector for convenience
     inline std::ostream & operator << (std::ostream & os, const types::ShapeType & coord) {
         os << "Coordinates(";
         for(const auto & cc: coord) {

--- a/include/z5/util/format_data.hxx
+++ b/include/z5/util/format_data.hxx
@@ -162,7 +162,7 @@ namespace util {
         memcpy(&ndim, &buffer[2], 2);
         util::reverseEndiannessInplace(ndim);
 
-        // read tempory shape with uint32 entries
+        // read temporary shape with uint32 entries
         std::vector<uint32_t> shape(ndim);
         for(int d = 0; d < ndim; ++d) {
             memcpy(&shape[d], &buffer[(d + 1) * 4], 4);

--- a/include/z5/util/util.hxx
+++ b/include/z5/util/util.hxx
@@ -29,7 +29,7 @@ namespace util {
         out.push_back(in.substr(prev, curr - prev));
     }
 
-    // make regular grid betwee `minCoords` and `maxCoords` with step size 1.
+    // make regular grid between `minCoords` and `maxCoords` with step size 1.
     // uses imglib trick for ND code.
     inline void makeRegularGrid(const types::ShapeType & minCoords,
                                 const types::ShapeType & maxCoords,

--- a/src/python/lib/handles.cxx
+++ b/src/python/lib/handles.cxx
@@ -152,7 +152,7 @@ namespace z5 {
 
         auto f = getGroupHandle<File, File, Dataset>(m, "S3File");
         f
-            // dummy construnctor
+            // dummy constructor
             .def(py::init<const std::string &, const std::string &, FileMode>(),
                  py::arg("bucket_name"), py::arg("name_in_bucket"), py::arg("mode"))
         ;

--- a/src/python/module/z5py/converter.py
+++ b/src/python/module/z5py/converter.py
@@ -115,7 +115,7 @@ if imageio:
     def default_index_parser(fname):
         # get rid of the postfix
         parsed = os.path.splitext(fname)[0]
-        # try to convert to interger directly
+        # try to convert to integer directly
         if is_int(parsed):
             return int(parsed)
         # try to split at '_'
@@ -173,7 +173,7 @@ if imageio:
                 otherwise zarr will be used (default: None).
             parser (callable): function to parse the image indices for tifs in a folder.
                 If None, some default patterns are tried (default: None)
-            process (callable): function to preprocess chunks before wrting to n5/zarr
+            process (callable): function to preprocess chunks before writing to n5/zarr
                 Must take np.ndarray and int as arguments. (default: None)
             **z5_kwargs: keyword arguments for ``z5py`` dataset, e.g. datatype or compression.
         """

--- a/src/python/module/z5py/file.py
+++ b/src/python/module/z5py/file.py
@@ -31,7 +31,7 @@ class File(Group):
         """ Infer the file format from the file extension.
 
             Returns:
-                bool: `True` for zarr, `False` for n5 and `None` if the format could not be infered.
+                bool: `True` for zarr, `False` for n5 and `None` if the format could not be inferred.
         """
         # first, try to infer the format from the file ending
         is_zarr = None
@@ -53,7 +53,7 @@ class File(Group):
             path = os.fspath(path)
         # infer the file format from the path
         is_zarr = self.infer_format(path)
-        # check if the format that was infered is consistent with `use_zarr_format`
+        # check if the format that was inferred is consistent with `use_zarr_format`
         if use_zarr_format is None:
             if is_zarr is None:
                 raise RuntimeError("Cannot infer the file format (zarr or N5)")

--- a/src/python/module/z5py/group.py
+++ b/src/python/module/z5py/group.py
@@ -241,7 +241,7 @@ class Group(Mapping):
 
         Returning None continues iteration, returning anything else stops
         and immediately returns that value from the visit method.  No
-        particular order of iteration within groups is guranteed.
+        particular order of iteration within groups is guaranteed.
 
         calls the function @param func with the found items, appended to @param path
 

--- a/src/python/module/z5py/util.py
+++ b/src/python/module/z5py/util.py
@@ -80,7 +80,7 @@ def copy_dataset_impl(f_in, f_out, in_path_in_file, out_path_in_file,
 
     Used to implement `copy_dataset`, `convert_to_h5` and `convert_from_h5`.
     Can also be used for more flexible use cases, like copying from a zarr/n5
-    cloud dataset to a filesytem dataset.
+    cloud dataset to a filesystem dataset.
 
     Args:
         f_in (File): input file object.
@@ -351,7 +351,7 @@ def remove_trivial_chunks(dataset, n_threads,
 
 
 def remove_dataset(dataset, n_threads):
-    """ Remvoe dataset multi-threaded.
+    """ Remove dataset multi-threaded.
     """
     _z5py.remove_dataset(dataset._impl, n_threads)
 

--- a/src/python/test/test_zarr.py
+++ b/src/python/test/test_zarr.py
@@ -61,7 +61,7 @@ class ZarrTestMixin(ABC):
 
         # conda-forge version of numcodecs is not up-to-data
         # for python 3.5 and GZip is missing
-        # thats why we need to check explicitly here to not fail the test
+        # that's why we need to check explicitly here to not fail the test
         if hasattr(numcodecs, 'GZip'):
             zarr_compressors.update({'gzip': numcodecs.GZip()})
 

--- a/src/test/test_dataset.cxx
+++ b/src/test/test_dataset.cxx
@@ -90,7 +90,7 @@ namespace z5 {
         int dataTmp[size_];
         ASSERT_THROW(ds->readChunk(types::ShapeType({0, 0, 0}), dataTmp), std::runtime_error);
 
-        // test for 10 random chuks
+        // test for 10 random chunks
         for(unsigned _ = 0; _ < 10; ++_) {
             // get a random chunk
             types::ShapeType chunkId(ds->dimension());

--- a/src/test/test_n5/n5_java/src/test/java/zarr_pp/n5/AppTest.java
+++ b/src/test/test_n5/n5_java/src/test/java/zarr_pp/n5/AppTest.java
@@ -29,7 +29,7 @@ public class AppTest
     }
 
     /**
-     * Rigourous Test :-)
+     * Rigorous Test :-)
      */
     public void testApp()
     {


### PR DESCRIPTION
Mostly in code comments but also in the documentation.