### PR TITLE
Remove xtensor-python dependency if no Python interface needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,8 +209,10 @@ include_directories(${Boost_INCLUDE_DIR})
 find_package(xtensor REQUIRED)
 include_directories(xtensor_INCLUDE_DIRS)
 
-find_package(xtensor-python REQUIRED)
-include_directories(xtensor-python_INCLUDE_DIRS)
+if(BUILD_Z5PY)
+    find_package(xtensor-python REQUIRED)
+    include_directories(xtensor-python_INCLUDE_DIRS)
+endif()
 
 find_package(xsimd)
 if(xsimd_FOUND)


### PR DESCRIPTION
I believe if the Python interface is not needed, than we can drop xtensor-python requirement.