### PR TITLE
const static → static const

### DIFF
--- a/src/test/test_dataset.cxx
+++ b/src/test/test_dataset.cxx
@@ -72,7 +72,7 @@ namespace z5 {
         nlohmann::json jInt_;
         nlohmann::json jFloat_;
 
-        const static std::size_t size_ = 10*10*10;
+        static const std::size_t size_ = 10*10*10;
         int dataInt_[size_];
         float dataFloat_[size_];
 


### PR DESCRIPTION
Although both are legal in C++, the latter is prevalent and ISO C99 reads:

> 6.11.5 Storage-class specifiers
> 
> 1 The placement of a storage-class specifier other than at the beginning of the declaration specifiers in a declaration is an obsolescent feature.