### PR TITLE
Replace distutils module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: .github/workflows/environment.yaml
+          create-args: >-
+            python=${{ matrix.python-version }}
 
       - name: Build unix
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout

--- a/.github/workflows/environment.yaml
+++ b/.github/workflows/environment.yaml
@@ -10,7 +10,7 @@ dependencies:
   - zlib
   - xtensor >=0.24,<0.25
   - xtensor-python >=0.26,<0.27
-  - xsimd >=8,<9
+  - xsimd >=10,<11
   - blosc
   - imageio
   - nlohmann_json

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -119,15 +119,10 @@ add_subdirectory(lib)
 
 # Find the python install dir
 IF(NOT DEFINED PYTHON_MODULE_INSTALL_DIR OR PYTHON_MODULE_INSTALL_DIR MATCHES "^$")
-
+    
     execute_process(
       COMMAND "${PYTHON_EXECUTABLE}" -c 
-       "from __future__ import print_function; from distutils import sysconfig as sc; print(sc.get_python_lib(prefix='', plat_specific=True))"
-      OUTPUT_VARIABLE PYTHON_SITE
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    execute_process(
-      COMMAND "${PYTHON_EXECUTABLE}" -c "from __future__ import print_function; from distutils.sysconfig import get_python_lib; print(get_python_lib())"
+       "from __future__ import print_function; import sysconfig; print(sysconfig.get_path('platlib'))"
       OUTPUT_VARIABLE PYTHON_SITE
       OUTPUT_STRIP_TRAILING_WHITESPACE)
 


### PR DESCRIPTION
Since `distutils` module is deprecated in Python 3.12, using `sysconfig` module to get Python site-package location