### PR TITLE
Add Complex Number Support

### DIFF
--- a/include/z5/filesystem/factory.hxx
+++ b/include/z5/filesystem/factory.hxx
@@ -42,6 +42,10 @@ namespace filesystem {
                 ptr.reset(new Dataset<float>(dataset, metadata)); break;
             case types::float64:
                 ptr.reset(new Dataset<double>(dataset, metadata)); break;
+            case types::complex64:
+                ptr.reset(new Dataset<std::complex<float>>(dataset, metadata)); break;
+            case types::complex128:
+                ptr.reset(new Dataset<std::complex<double>>(dataset, metadata)); break;
         }
         return ptr;
     }

--- a/include/z5/filesystem/factory.hxx
+++ b/include/z5/filesystem/factory.hxx
@@ -82,6 +82,10 @@ namespace filesystem {
                 ptr.reset(new Dataset<float>(dataset, metadata)); break;
             case types::float64:
                 ptr.reset(new Dataset<double>(dataset, metadata)); break;
+            case types::complex64:
+                ptr.reset(new Dataset<std::complex<float>>(dataset, metadata)); break;
+            case types::complex128:
+                ptr.reset(new Dataset<std::complex<double>>(dataset, metadata)); break;
         }
         return ptr;
     }

--- a/include/z5/filesystem/factory.hxx
+++ b/include/z5/filesystem/factory.hxx
@@ -46,6 +46,8 @@ namespace filesystem {
                 ptr.reset(new Dataset<std::complex<float>>(dataset, metadata)); break;
             case types::complex128:
                 ptr.reset(new Dataset<std::complex<double>>(dataset, metadata)); break;
+            case types::complex256:
+                ptr.reset(new Dataset<std::complex<long double>>(dataset, metadata)); break;
         }
         return ptr;
     }
@@ -86,6 +88,8 @@ namespace filesystem {
                 ptr.reset(new Dataset<std::complex<float>>(dataset, metadata)); break;
             case types::complex128:
                 ptr.reset(new Dataset<std::complex<double>>(dataset, metadata)); break;
+            case types::complex256:
+                ptr.reset(new Dataset<std::complex<long double>>(dataset, metadata)); break;
         }
         return ptr;
     }

--- a/include/z5/metadata.hxx
+++ b/include/z5/metadata.hxx
@@ -143,6 +143,8 @@ namespace z5 {
                 } else {
                     throw std::runtime_error("Invalid string value for fillValue");
                 }
+            } else if(fillValJson.type() == nlohmann::json::value_t::null) {
+                fillValue = std::numeric_limits<double>::quiet_NaN();
             } else {
                 fillValue = static_cast<double>(fillValJson);
             }

--- a/include/z5/types/types.hxx
+++ b/include/z5/types/types.hxx
@@ -28,7 +28,8 @@ namespace types {
     enum Datatype {
         int8, int16, int32, int64,
         uint8, uint16, uint32, uint64,
-        float32, float64
+        float32, float64,
+        complex64, complex128
     };
 
     struct Datatypes {
@@ -38,7 +39,8 @@ namespace types {
         static DtypeMap & zarrToDtype() {
             static DtypeMap dtypeMap({{{"|i1", int8}, {"<i2", int16}, {"<i4", int32}, {"<i8", int64},
                                        {"|u1", uint8}, {"<u2", uint16}, {"<u4", uint32}, {"<u8", uint64},
-                                       {"<f4", float32}, {"<f8", float64}}});
+                                       {"<f4", float32}, {"<f8", float64},
+                                       {"<c8", complex64}, {"<c16", complex128}}});
             return dtypeMap;
         }
 
@@ -46,7 +48,8 @@ namespace types {
 
             static InverseDtypeMap dtypeMap({{{int8   , "|i1"}, {int16,  "<i2"}, {int32, "<i4"}, {int64, "<i8"},
                                               {uint8  , "|u1"}, {uint16, "<u2"}, {uint32, "<u4"},{uint64,"<u8"},
-                                              {float32, "<f4"}, {float64,"<f8"}}});
+                                              {float32, "<f4"}, {float64,"<f8"},
+                                              {complex64, "<c8"}, {complex128, "<c16"}}});
             return dtypeMap;
         }
 

--- a/include/z5/types/types.hxx
+++ b/include/z5/types/types.hxx
@@ -5,6 +5,7 @@
 #include <string>
 #include <map>
 #include <variant>
+#include <complex>
 
 #include "nlohmann/json.hpp"
 
@@ -29,7 +30,7 @@ namespace types {
         int8, int16, int32, int64,
         uint8, uint16, uint32, uint64,
         float32, float64,
-        complex64, complex128
+        complex64, complex128, complex256
     };
 
     struct Datatypes {
@@ -40,7 +41,7 @@ namespace types {
             static DtypeMap dtypeMap({{{"|i1", int8}, {"<i2", int16}, {"<i4", int32}, {"<i8", int64},
                                        {"|u1", uint8}, {"<u2", uint16}, {"<u4", uint32}, {"<u8", uint64},
                                        {"<f4", float32}, {"<f8", float64},
-                                       {"<c8", complex64}, {"<c16", complex128}}});
+                                       {"<c8", complex64}, {"<c16", complex128}, {"<c32", complex256}}});
             return dtypeMap;
         }
 
@@ -49,7 +50,7 @@ namespace types {
             static InverseDtypeMap dtypeMap({{{int8   , "|i1"}, {int16,  "<i2"}, {int32, "<i4"}, {int64, "<i8"},
                                               {uint8  , "|u1"}, {uint16, "<u2"}, {uint32, "<u4"},{uint64,"<u8"},
                                               {float32, "<f4"}, {float64,"<f8"},
-                                              {complex64, "<c8"}, {complex128, "<c16"}}});
+                                              {complex64, "<c8"}, {complex128, "<c16"}, {complex256, "<c32"}}});
             return dtypeMap;
         }
 

--- a/src/python/lib/dataset.cxx
+++ b/src/python/lib/dataset.cxx
@@ -228,6 +228,9 @@ namespace z5 {
         // float types
         exportIoT<float>(module, "float32");
         exportIoT<double>(module, "float64");
+        // complex types
+        exportIoT<std::complex<float>>(module, "complex64");
+        exportIoT<std::complex<double>>(module, "complex128");
 
         // export writing scalars
         // The overloads cannot be properly resolved,
@@ -280,6 +283,14 @@ namespace z5 {
                         case types::Datatype::float64 : writePyScalar<double>(ds, roiBegin, roiShape,
                                                                               static_cast<double>(val),
                                                                               numberOfThreads);
+                                                        break;
+                        case types::Datatype::complex64 : writePyScalar<std::complex<float>>(ds, roiBegin, roiShape,
+                                                                              static_cast<std::complex<float>>(val),
+                                                                              numberOfThreads);
+                                                        break;
+                        case types::Datatype::complex128 : writePyScalar<std::complex<double>>(ds, roiBegin, roiShape,
+                                                        static_cast<std::complex<double>>(val),
+                                                        numberOfThreads);
                                                         break;
                         default: throw(std::runtime_error("Invalid datatype"));
 

--- a/src/python/lib/dataset.cxx
+++ b/src/python/lib/dataset.cxx
@@ -231,6 +231,7 @@ namespace z5 {
         // complex types
         exportIoT<std::complex<float>>(module, "complex64");
         exportIoT<std::complex<double>>(module, "complex128");
+        exportIoT<std::complex<long double>>(module, "complex256");
 
         // export writing scalars
         // The overloads cannot be properly resolved,
@@ -289,8 +290,12 @@ namespace z5 {
                                                                               numberOfThreads);
                                                         break;
                         case types::Datatype::complex128 : writePyScalar<std::complex<double>>(ds, roiBegin, roiShape,
-                                                        static_cast<std::complex<double>>(val),
-                                                        numberOfThreads);
+                                                                              static_cast<std::complex<double>>(val),
+                                                                              numberOfThreads);
+                                                        break;
+                        case types::Datatype::complex256 : writePyScalar<std::complex<long double>>(ds, roiBegin, roiShape,
+                                                                              static_cast<std::complex<long double>>(val),
+                                                                              numberOfThreads);
                                                         break;
                         default: throw(std::runtime_error("Invalid datatype"));
 


### PR DESCRIPTION
NPY and Zarr support complex floating point tensors with the `<c` dtype prefix, but are not yet supported by z5. This changeset adds support for 3 fixed sized complex dtypes made available and tested using the C++ standard library `std::complex<T>`.

External to this PR I've tested loading complex tensors from Zarr but not N5, if there's evidence N5 does support complex numbers I'd be open to exploring support for N5 too.