### PR TITLE
Add Python 3.14 wheels and bump version

### DIFF
--- a/include/z5/z5.hxx
+++ b/include/z5/z5.hxx
@@ -2,4 +2,4 @@
 
 #define Z5_VERSION_MAJOR 3
 #define Z5_VERSION_MINOR 0
-#define Z5_VERSION_PATCH 1
+#define Z5_VERSION_PATCH 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 
@@ -86,7 +87,7 @@ result = "{major}.{minor}.{patch}"
 [tool.cibuildwheel]
 # zarr-python 3 (the interop test target) requires Python >= 3.11, matching this
 # package's requires-python, so the build matrix starts at cp311.
-build = "cp311-* cp312-* cp313-*"
+build = "cp311-* cp312-* cp313-* cp314-*"
 skip = "*-win32 *-manylinux_i686 *-musllinux_*"
 build-frontend = "build"
 # tensorstore is intentionally omitted here: it lacks wheels for some wheel


### PR DESCRIPTION
We need to see if we wanna / need to go ahead with it. I added py314 to wheel build matrix (noticed that some other packages around `micro-sam` indeed auto fetch py314 without many issues.

What do you think about this? @constantinpape 